### PR TITLE
Use `@example` tags in documentation's examples

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,7 +86,7 @@ You can obtain the current master with:
 ```
 
 # Quick example
-```julia
+```@example
 using Surrogates
 num_samples = 10
 lb = 0.0

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -2,22 +2,20 @@
 Let's start with something easy to get our hands dirty.
 I want to build a surrogate for ``f(x) = log(x)*x^2+x^3``.
 Let's choose the radial basis surrogate.
-```
+```@example
 using Surrogates
 f = x -> log(x)*x^2+x^3
 lb = 1.0
 ub = 10.0
 x = sample(50,lb,ub,SobolSample())
 y = f.(x)
-thin_plate_spline = x -> x^2*log(x)
-q = 2
-my_radial_basis = RadialBasis(x,y,lb,ub,thin_plate_spline,q)
+my_radial_basis = RadialBasis(x,y,lb,ub,rad=thinplateRadial)
 
 #I want an approximation at 5.4
 approx = my_radial_basis(5.4)
 ```
 Let's now see an example in 2D.
-```
+```@example
 using Surrogates
 using LinearAlgebra
 f = x -> x[1]*x[2]
@@ -25,9 +23,7 @@ lb = [1.0,2.0]
 ub = [10.0,8.5]
 x = sample(50,lb,ub,SobolSample())
 y = f.(x)
-linear = x -> norm(x)
-q = 1
-my_radial_basis = RadialBasis(x,y,[lb,ub],linear,q)
+my_radial_basis = RadialBasis(x,y,lb,ub)
 
 #I want an approximation at (1.0,1.4)
 approx = my_radial_basis((1.0,1.4))
@@ -38,7 +34,7 @@ Let's now use the Kriging surrogate, which is a single-output Gaussian process.
 This surrogate has a nice feature: not only does it approximate the solution at a
 point, it also calculates the standard error at such point.
 Let's see an example:
-```
+```@example kriging
 using Surrogates
 f = x -> exp(x)*x^2+x^3
 lb = 0.0
@@ -46,7 +42,7 @@ ub = 10.0
 x = sample(100,lb,ub,UniformSample())
 y = f.(x)
 p = 1.9
-my_krig = Kriging(x,y,p)
+my_krig = Kriging(x,y,lb,ub,p=p)
 
 #I want an approximation at 5.4
 approx = my_krig(5.4)
@@ -56,14 +52,14 @@ std_err = std_error_at_point(my_krig,5.4)
 ```
 
 Let's now optimize the Kriging surrogate using Lower confidence bound method, this is just a one-liner:
-```
-surrogate_optimize(f,LCBS(),a,b,my_krig,UniformSample())
+```@example kriging
+surrogate_optimize(f,LCBS(),lb,ub,my_krig,UniformSample())
 ```
 ## Lobachesky integral
 The Lobachesky surrogate has the nice feature of having a closed formula for its
 integral, which is something that other surrogates are missing.
 Let's compare it with QuadGK:
-```
+```@examples
 using Surrogates
 using QuadGK
 obj = x -> 3*x + log(x)
@@ -73,19 +69,19 @@ x = sample(2000,a,b,SobolSample())
 y = obj.(x)
 alpha = 2.0
 n = 6
-my_loba = LobacheskySurrogate(x,y,alpha,n,a,b)
+my_loba = LobacheskySurrogate(x,y,a,b,alpha=alpha,n=n)
 
 #1D integral
 int_1D = lobachesky_integral(my_loba,a,b)
 int = quadgk(obj,a,b)
 int_val_true = int[1]-int[2]
-@test abs(int_1D - int_val_true) < 10^-5
+@assert int_1D ≈ int_val_true
 ```
 
 
 ## Example of NeuralSurrogate
 Basic example of fitting a neural network on a simple function of two variables.
-```
+```@example
 using Surrogates
 using Flux
 using Statistics
@@ -106,7 +102,7 @@ loss(x, y) = Flux.mse(model(x), y)
 learning_rate = 0.1
 optimizer = Descent(learning_rate)  # Simple gradient descent. See Flux documentation for other options.
 n_epochs = 50
-sgt = NeuralSurrogate(x_train, y_train, bounds..., model, loss, optimizer, n_epochs)
+sgt = NeuralSurrogate(x_train, y_train, bounds..., model=model, loss=loss, opt=optimizer, n_echos=n_epochs)
 
 # Testing the new model
 x_test = sample(30, bounds..., SobolSample())

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -51,8 +51,8 @@ function RadialBasis(x, y, lb, ub; rad::RadialFunction = linearRadial, scale_fac
 end
 
 function _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
-    @show D = _construct_rbf_interp_matrix(x, first(x), lb, ub, phi, q, scale_factor, sparse)
-    @show Y = _construct_rbf_y_matrix(y, first(y), length(y) + q)
+    D = _construct_rbf_interp_matrix(x, first(x), lb, ub, phi, q, scale_factor, sparse)
+    Y = _construct_rbf_y_matrix(y, first(y), length(y) + q)
     coeff = D \ Y
     return coeff
 end

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -21,7 +21,10 @@ end
 linearRadial = RadialFunction(0,z->norm(z))
 cubicRadial = RadialFunction(1,z->norm(z)^3)
 multiquadricRadial = RadialFunction(1,z->sqrt(norm(z)^2+1))
-thinplateRadial = RadialFunction(2,z->norm(z)^2*log(norm(z)))
+thinplateRadial = RadialFunction(2, z->begin
+    result = norm(z)^2 * log(norm(z))
+    ifelse(iszero(z), zero(result), result)
+end)
 
 """
     RadialBasis(x,y,lb::Number,ub::Number; rad::RadialFunction = linearRadial,scale::Real=1.0)
@@ -48,8 +51,8 @@ function RadialBasis(x, y, lb, ub; rad::RadialFunction = linearRadial, scale_fac
 end
 
 function _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
-    D = _construct_rbf_interp_matrix(x, first(x), lb, ub, phi, q, scale_factor, sparse)
-    Y = _construct_rbf_y_matrix(y, first(y), length(y) + q)
+    @show D = _construct_rbf_interp_matrix(x, first(x), lb, ub, phi, q, scale_factor, sparse)
+    @show Y = _construct_rbf_y_matrix(y, first(y), length(y) + q)
     coeff = D \ Y
     return coeff
 end


### PR DESCRIPTION
This PR changes all of the documentation's examples to use Documenter.jl's `@example` tags. While doing this I have converted the examples to use the new kwarg functions and fixed a small NaN bug in the definition on `thinplateRadial`'s phi function.