### PR TITLE
Add docs dependencies

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+
 [compat]
 Documenter = "0.24.2"


### PR DESCRIPTION
Adds the necessary packages needed to build the documentation.

In the output of the [latest `documenter` run](https://github.com/SciML/Surrogates.jl/runs/783214953?check_suite_focus=true) (click the `build and deploy` dropdown) we can see that many fails were due to missing packages. In particular:

```
┌ Warning: failed to run `@example` block in src/kriging.md:8-11
│ ```@example kriging_tutorial
│ using Surrogates
│ using Plots
│ ```
│   value =
│    ArgumentError: Package Plots not found in current path:
│    - Run `import Pkg; Pkg.add("Plots")` to install the Plots package.
│    
└ @ Documenter.Expanders ~/.julia/packages/Documenter/PLD7m/src/Expanders.jl:564

... Rest of the file ...
```

In addition we may want to make the `documenter` action fail whenever building the docs fails.