### PR TITLE
Fix off-by-one error in radial polynomial degree

### DIFF
--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -32,7 +32,7 @@ end)
 Constructor for RadialBasis surrogate.
 """
 function RadialBasis(x, y, lb::Number, ub::Number; rad::RadialFunction=linearRadial, scale_factor::Real=1.0, sparse = false)
-    q = rad.q
+    q = rad.q + 1
     phi = rad.phi
     coeff = _calc_coeffs(x, y, lb, ub, phi, q,scale_factor, sparse)
     return RadialBasis(phi, q, x, y, lb, ub, coeff,scale_factor,sparse)
@@ -44,7 +44,7 @@ RadialBasis(x,y,lb,ub,rad::RadialFunction, scale_factor::Float = 1.0)
 Constructor for RadialBasis surrogate
 """
 function RadialBasis(x, y, lb, ub; rad::RadialFunction = linearRadial, scale_factor::Real=1.0, sparse = false)
-    q = rad.q
+    q = rad.q + 1
     phi = rad.phi
     coeff = _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
     return RadialBasis(phi, q, x, y, lb, ub, coeff,scale_factor, sparse)


### PR DESCRIPTION
Changing the definition of `q` this early in executions is the simplest fix but changing it inside ` _construct_rbf_interp_matrix`, `_construct_rbf_y_matrix` and ` _approx_rbf` could be in some sense cleaner. Let me know what you prefer.