### PR TITLE
Tutorials first

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,11 +3,6 @@ makedocs(
     sitename="Surrogates.jl",
     pages = [
     "index.md"
-    "User guide" => [
-        "Samples" => "samples.md",
-        "Surrogates" => "surrogate.md",
-        "Optimization" => "optimizations.md"
-        ]
     "Tutorials" => [
         "Basics" => "tutorials.md",
         "RandomForestSurrogate" => "randomforest.md",
@@ -16,6 +11,11 @@ makedocs(
         "Lobachesky" => "lobachesky.md",
         "LinearSurrogate" => "LinearSurrogate.md",
         "InverseDistance" => "InverseDistance.md"
+        ]
+    "User guide" => [
+        "Samples" => "samples.md",
+        "Surrogates" => "surrogate.md",
+        "Optimization" => "optimizations.md"
         ]
     "Benchmarks" => [
         "Sphere function" => "sphere_function.md"


### PR DESCRIPTION
I always think a tutorials first approach to documentation is much more inviting, because it becomes immediately clear to the user (a) what is solved and (b) how to use it. All of the extra details of what other things you can choose to do can come after the tutorial, but most people want to just look at the first tutorial, copy/paste, and run.

With that in mind, I think the first tutorial could use a bit more. I think a demonstration of surrogate optimization should appear in that first page, otherwise most people won't know it exists.