### PR TITLE
Project.toml: remove packages from [extras] that occur in [deps]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,14 +36,10 @@ julia = "1"
 
 [extras]
 Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-Stheno = "8188c328-b5d6-583d-959b-9690869a5511"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
 test = ["Cubature", "ForwardDiff", "Flux", "QuadGK", "Test", "Tracker", "XGBoost", "Zygote", "Stheno"]

--- a/Project.toml
+++ b/Project.toml
@@ -42,4 +42,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["Cubature", "ForwardDiff", "Flux", "QuadGK", "Test", "Tracker", "XGBoost", "Zygote", "Stheno"]
+test = ["Cubature", "ForwardDiff", "QuadGK", "Test", "Tracker"]


### PR DESCRIPTION
Fixes #247 

I'm not sure why this was necessary given that the offending packages were all also in deps. But after making this change, I was able to precompile without any warning messages. 