### PR TITLE
Project.toml: update to include `Flux` and `PolyChaos` as `deps`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "4.0.0"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ExtendableSparse = "95c220a8-a1cf-11e9-0c77-dbfce5f500b3"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LatinHypercubeSampling = "a5e1c1ea-c99a-51d3-a14d-a9a37257b02d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PolyChaos = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Sobol = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -33,13 +35,11 @@ julia = "1.5"
 
 [extras]
 Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-PolyChaos = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Stheno = "8188c328-b5d6-583d-959b-9690869a5511"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["Cubature", "Flux", "ForwardDiff", "PolyChaos", "QuadGK", "Stheno", "Test", "Tracker"]
+test = ["Cubature", "ForwardDiff", "QuadGK", "Stheno", "Test", "Tracker"]


### PR DESCRIPTION
Add `Flux` and `PolyChaos` as `deps` since they're being `@require`-d in
the package.

This fixes the warning:
```
┌ Warning: Package Surrogates does not have Flux in its dependencies:
│ - If you have Surrogates checked out for development and have
│   added Flux as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Surrogates
└ Loading Flux into Surrogates from project dependency, future warnings for Surrogates are suppressed.
```