### PR TITLE
Minor cleanup of AbstractGPSurrogate

### DIFF
--- a/src/AbstractGP.jl
+++ b/src/AbstractGP.jl
@@ -15,7 +15,7 @@ function AbstractGPSurrogate(x, y; gp = GP(Matern52Kernel()), Σy = 0.1)
 
 # predictor 
 function (g::AbstractGPSurrogate)(val::Real)
-    return first(mean(g.gp_posterior([val])))
+    return only(mean(g.gp_posterior([val])))
 end
 
 # for add point
@@ -42,7 +42,7 @@ function var_at_point(g::AbstractGPSurrogate, val::AbstractVector)
 end
 
 function std_error_at_point(g::AbstractGPSurrogate, val::Real)
-    return sqrt(first(var(g.gp_posterior([val]))))
+    return sqrt(only(var(g.gp_posterior([val]))))
 end
 
 

--- a/src/AbstractGP.jl
+++ b/src/AbstractGP.jl
@@ -1,6 +1,6 @@
 using AbstractGPs
 
-mutable struct AbstractGPStruct{X, Y, GP, GP_P, S} <: AbstractSurrogate
+mutable struct AbstractGPSurrogate{X, Y, GP, GP_P, S} <: AbstractSurrogate
     x::X
     y::Y
     gp::GP 
@@ -10,18 +10,18 @@ mutable struct AbstractGPStruct{X, Y, GP, GP_P, S} <: AbstractSurrogate
 
 # constructor
 function AbstractGPSurrogate(x, y; gp = GP(Matern52Kernel()), Σy = 0.1)
-    AbstractGPStruct(x, y, gp, posterior(gp(x, Σy),y), Σy)
+    AbstractGPSurrogate(x, y, gp, posterior(gp(x, Σy),y), Σy)
  end
 
 # predictor 
-function (g::AbstractGPStruct)(val)
+function (g::AbstractGPSurrogate)(val::Real)
     return first(mean(g.gp_posterior([val])))
 end
 
 # for add point
 # copies of x and y need to be made because we get 
 #"Error: cannot resize array with shared data " if we push! directly to x and y  
-function add_point!(g::AbstractGPStruct, new_x, new_y)
+function add_point!(g::AbstractGPSurrogate, new_x, new_y)
     if new_x in g.x
         println("Adding a sample that already exists, cannot build AbstracgGPSurrogate.")
         return
@@ -37,16 +37,16 @@ end
 
 
 # returns diagonal elements of cov(f)
-function var_at_point(g::AbstractGPStruct, val)
+function var_at_point(g::AbstractGPSurrogate, val::AbstractVector)
     return var(g.gp_posterior(val))
 end
 
-function std_error_at_point(g::AbstractGPStruct, val)
+function std_error_at_point(g::AbstractGPSurrogate, val::Real)
     return sqrt(first(var(g.gp_posterior([val]))))
 end
 
 
 # Log marginal posterior predictive probability.
-function logpdf_surrogate(g::AbstractGPStruct)
+function logpdf_surrogate(g::AbstractGPSurrogate)
     return logpdf(g.gp_posterior(g.x), g.y)
 end

--- a/src/AbstractGP.jl
+++ b/src/AbstractGP.jl
@@ -14,7 +14,7 @@ function AbstractGPSurrogate(x, y; gp = GP(Matern52Kernel()), Σy = 0.1)
  end
 
 # predictor 
-function (g::AbstractGPSurrogate)(val::Real)
+function (g::AbstractGPSurrogate)(val)
     return only(mean(g.gp_posterior([val])))
 end
 
@@ -37,11 +37,11 @@ end
 
 
 # returns diagonal elements of cov(f)
-function var_at_point(g::AbstractGPSurrogate, val::AbstractVector)
-    return var(g.gp_posterior(val))
+function var_at_point(g::AbstractGPSurrogate, val)
+    return only(var(g.gp_posterior([val])))
 end
 
-function std_error_at_point(g::AbstractGPSurrogate, val::Real)
+function std_error_at_point(g::AbstractGPSurrogate, val)
     return sqrt(only(var(g.gp_posterior([val]))))
 end
 

--- a/test/AbstractGP.jl
+++ b/test/AbstractGP.jl
@@ -69,7 +69,7 @@ end
     x = sample(5,lb,ub,SobolSample())
     y = f.(x)
     agp1D = AbstractGPSurrogate(x,y, gp=GP(SqExponentialKernel()), Σy=0.05)
-    x_new = [2.5]
+    x_new = 2.5
     var_at_point(agp1D, x_new)
 end
 
@@ -80,9 +80,9 @@ end
     x = sample(25,lb,ub,SobolSample())
     y = f.(x)
     agpND = AbstractGPSurrogate(x, y, gp = GP(SqExponentialKernel()), Σy = 0.05)
-    x_new = [(-0.8,0.8,0.8)]
+    x_new = (-0.8,0.8,0.8)
     var_at_point(agpND, x_new)
-    @test isapprox(agpND(first(x_new)), f(first(x_new)), atol=0.2)
+    @test agpND(x_new) ≈ f(x_new) atol=0.2
 end
 
 @testset "Optimization 1D" begin


### PR DESCRIPTION
- brings the name of the struct in line with its constructor, as for other surrogates
- is more specific about types to prevent buggy calls (AbstractGPs `GP` always requires to be called with an AbstractVector)

Note that the surrogate as-is performs badly in practice (as already noted in #251 for the mostly-equivalent `Kriging`); improving this would require rather more work, including better hyperparameter initialisation, priors, and optimising the kernel hyperparameters in each update.