### PR TITLE
Introduce shape parameter for multiquadric radial function

### DIFF
--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -22,7 +22,7 @@ end
 
 linearRadial() = RadialFunction(0,z->norm(z))
 cubicRadial() = RadialFunction(1,z->norm(z)^3)
-multiquadricRadial(ϵ = 1.0) = RadialFunction(1,z->sqrt((ϵ*norm(z))^2+1))
+multiquadricRadial(c = 1.0) = RadialFunction(1,z->sqrt((c*norm(z))^2+1))
 
 thinplateRadial() = RadialFunction(2, z->begin
     result = norm(z)^2 * log(norm(z))

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -20,21 +20,21 @@ mutable struct RadialFunction{Q,P}
     phi::P
 end
 
-const linearRadial = RadialFunction(0,z->norm(z))
-const cubicRadial = RadialFunction(1,z->norm(z)^3)
-const multiquadricRadial = RadialFunction(1,z->sqrt(norm(z)^2+1))
+linearRadial() = RadialFunction(0,z->norm(z))
+cubicRadial() = RadialFunction(1,z->norm(z)^3)
+multiquadricRadial(ϵ = 1.0) = RadialFunction(1,z->sqrt((ϵ*norm(z))^2+1))
 
-const thinplateRadial = RadialFunction(2, z->begin
+thinplateRadial() = RadialFunction(2, z->begin
     result = norm(z)^2 * log(norm(z))
     ifelse(iszero(z), zero(result), result)
 end)
 
 """
-    RadialBasis(x,y,lb::Number,ub::Number; rad::RadialFunction = linearRadial,scale::Real=1.0)
+    RadialBasis(x,y,lb::Number,ub::Number; rad::RadialFunction = linearRadial(),scale::Real=1.0)
 
 Constructor for RadialBasis surrogate.
 """
-function RadialBasis(x, y, lb::Number, ub::Number; rad::RadialFunction=linearRadial, scale_factor::Real=0.5, sparse = false)
+function RadialBasis(x, y, lb::Number, ub::Number; rad::RadialFunction=linearRadial(), scale_factor::Real=0.5, sparse = false)
     q = rad.q
     phi = rad.phi
     coeff = _calc_coeffs(x, y, lb, ub, phi, q,scale_factor, sparse)
@@ -46,7 +46,7 @@ RadialBasis(x,y,lb,ub,rad::RadialFunction, scale_factor::Float = 1.0)
 
 Constructor for RadialBasis surrogate
 """
-function RadialBasis(x, y, lb, ub; rad::RadialFunction = linearRadial, scale_factor::Real=0.5, sparse = false)
+function RadialBasis(x, y, lb, ub; rad::RadialFunction = linearRadial(), scale_factor::Real=0.5, sparse = false)
     q = rad.q
     phi = rad.phi
     coeff = _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
@@ -188,7 +188,7 @@ function _approx_rbf(val, rad::R) where {R}
     approx = Buffer(zeros(eltype(val), l), false)
 
 
-    if rad.phi === linearRadial.phi
+    if rad.phi === linearRadial().phi
         for i in 1:n
             tmp = zero(eltype(val))
             @simd ivdep for j in 1:length(val)

--- a/src/VariableFidelity.jl
+++ b/src/VariableFidelity.jl
@@ -11,8 +11,8 @@ end
 
 function VariableFidelitySurrogate(x,y,lb,ub;
                                    num_high_fidel = Int(floor(length(x)/2)),
-                                   low_fid_structure = RadialBasisStructure(radial_function = linearRadial, scale_factor=1.0, sparse = false),
-                                   high_fid_structure = RadialBasisStructure(radial_function = cubicRadial ,scale_factor=1.0,sparse=false))
+                                   low_fid_structure = RadialBasisStructure(radial_function = linearRadial(), scale_factor=1.0, sparse = false),
+                                   high_fid_structure = RadialBasisStructure(radial_function = cubicRadial() ,scale_factor=1.0,sparse=false))
 
             x_high = x[1:num_high_fidel]
             x_low = x[num_high_fidel+1:end]

--- a/test/AD_compatibility.jl
+++ b/test/AD_compatibility.jl
@@ -119,7 +119,7 @@ end
 
 #Radials
 @testset "Radials 1D" begin
-    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial)
+    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial())
     g = x -> my_rad'(x)
     g(5.0)
 end
@@ -231,7 +231,7 @@ y = f.(x)
 
 #Radials
 @testset "Radials ND" begin
-    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial, scale_factor = 2.1)
+    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial(), scale_factor = 2.1)
     g = x -> Zygote.gradient(my_rad,x)
     g((2.0,5.0))
 end
@@ -355,7 +355,7 @@ y = f.(x)
     my_neural = NeuralSurrogate(x,y,lb,ub,model=my_model,loss=my_loss,opt=my_opt,n_echos=1)
     Zygote.gradient(x -> sum(my_neural(x)), (2.0, 5.0))
 
-    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial)
+    my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial())
     Zygote.gradient(x -> sum(my_rad(x)), (2.0, 5.0))
 
     my_p = 1.4

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -14,7 +14,7 @@ cubic = x -> x^3
 λ = 2.3
 multiquadr = x -> sqrt(x^2+λ^2)
 q = 1
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial())
 est = my_rad(3.0)
 @test est ≈ 6.0
 add_point!(my_rad, 4.0, 10.0)
@@ -24,9 +24,9 @@ add_point!(my_rad,[3.2,3.3,3.4],[8.0,9.0,10.0])
 est = my_rad(3.0)
 @test est ≈ 6.0
 
-my_rad = RadialBasis(x, y, lb, ub, rad = cubicRadial)
+my_rad = RadialBasis(x, y, lb, ub, rad = cubicRadial())
 q = 2
-my_rad = RadialBasis(x,y,lb,ub, rad = multiquadricRadial)
+my_rad = RadialBasis(x,y,lb,ub, rad = multiquadricRadial())
 
 
 #ND
@@ -46,7 +46,7 @@ y = [4.0,5.0,6.0]
 lb = [0.0,3.0,6.0]
 ub = [4.0,7.0,10.0]
 #bounds = [[0.0,3.0,6.0],[4.0,7.0,10.0]]
-my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial, scale_factor = 1.0)
+my_rad = RadialBasis(x,y,lb,ub,rad = linearRadial(), scale_factor = 1.0)
 add_point!(my_rad,(9.0,10.0,11.0),10.0)
 est = my_rad((1.0,2.0,3.0))
 @test est ≈ 4.0
@@ -71,8 +71,8 @@ y = [4.0,5.0,6.0]
 my_rad_ND = RadialBasis(x,y,lb,ub)
 add_point!(my_rad_ND,(3.5,4.5,1.2),18.9)
 add_point!(my_rad_ND,[(3.2,1.2,6.7),(3.4,9.5,7.4)],[25.72,239.0])
-my_rad_ND = RadialBasis(x,y,lb,ub,rad = cubicRadial)
-my_rad_ND = RadialBasis(x,y,lb,ub, rad = multiquadricRadial)
+my_rad_ND = RadialBasis(x,y,lb,ub,rad = cubicRadial())
+my_rad_ND = RadialBasis(x,y,lb,ub, rad = multiquadricRadial())
 prediction = my_rad_ND((1.0,1.0,1.0))
 
 
@@ -82,9 +82,9 @@ ub = [10.0, 8.5]
 x = sample(500, lb, ub, SobolSample())
 push!(x, (1.0, 2.0))
 y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
 @test my_radial_basis((1.0, 2.0)) ≈ 2
-my_radial_basis = RadialBasis(x, y, lb, ub, rad =linearRadial)
+my_radial_basis = RadialBasis(x, y, lb, ub, rad =linearRadial())
 @test my_radial_basis((1.0, 2.0)) ≈ 2
 
 f = x -> x[1]*x[2]
@@ -93,7 +93,7 @@ ub = [10.0, 8.5]
 x = sample(5, lb, ub, SobolSample())
 push!(x, (1.0, 2.0))
 y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb,ub, rad = linearRadial)
+my_radial_basis = RadialBasis(x, y, lb,ub, rad = linearRadial())
 @test my_radial_basis((1.0, 2.0)) ≈ 2
 
 # Multi-output
@@ -103,7 +103,7 @@ ub = 10.0
 x  = sample(5, lb, ub, SobolSample())
 push!(x, 2.0)
 y  = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
 my_radial_basis(2.0)
 @test my_radial_basis(2.0) ≈ [4, 2]
 
@@ -113,7 +113,7 @@ ub = [10.0, 8.5]
 x  = sample(5, lb, ub, SobolSample())
 push!(x, (1.0, 2.0))
 y  = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
 my_radial_basis((1.0, 2.0))
 @test my_radial_basis((1.0, 2.0)) ≈ [2, 5]
 
@@ -131,7 +131,7 @@ lb = 0.0
 ub = 4.0
 x = [1.0,2.0,3.0]
 y = [4.0,5.0,6.0]
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial, sparse = true)
+my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), sparse = true)
 
 #ND
 x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
@@ -149,5 +149,7 @@ n_samples = 100
 g(x) = sqrt(x[1]^2 + x[2]^2 + x[3]^2) 
 x = sample(n_samples, lb, ub, SobolSample()) 
 y = g.(x) 
-mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial) 
+mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial()) 
 @test isapprox( mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = .0001)
+mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(0.9)) # different shape parameter should not be as accurate
+@test !isapprox( mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = .0001)

--- a/test/VariableFidelity.jl
+++ b/test/VariableFidelity.jl
@@ -14,7 +14,7 @@ val = my_varfid(3.0)
 
 my_varfid_change_struct = VariableFidelitySurrogate(x,y,lb,ub, num_high_fidel = 2,
                                                     low_fid_structure = InverseDistanceStructure(p = 1.0),
-                                                    high_fid_structure = RadialBasisStructure(radial_function = linearRadial, scale_factor=1.0,sparse = false))
+                                                    high_fid_structure = RadialBasisStructure(radial_function = linearRadial(), scale_factor=1.0,sparse = false))
 #ND
 n = 10
 lb = [0.0,0.0]
@@ -27,4 +27,4 @@ val = my_varfidND((2.0,2.0))
 add_point!(my_varfidND,(3.0,3.0),9.0)
 my_varfidND_change_struct = VariableFidelitySurrogate(x,y,lb,ub, num_high_fidel = 2,
                                                     low_fid_structure = InverseDistanceStructure(p = 1.0),
-                                                    high_fid_structure = RadialBasisStructure(radial_function = linearRadial, scale_factor=1.0,sparse = false))
+                                                    high_fid_structure = RadialBasisStructure(radial_function = linearRadial(), scale_factor=1.0,sparse = false))

--- a/test/optimization.jl
+++ b/test/optimization.jl
@@ -25,7 +25,7 @@ my_k_SRBF1 = Kriging(x,y,lb,ub)
 surrogate_optimize(objective_function,SRBF(),a,b,my_k_SRBF1,UniformSample())
 
 #Using RadialBasis
-my_rad_SRBF1 = RadialBasis(x,y,a,b,rad = linearRadial)
+my_rad_SRBF1 = RadialBasis(x,y,a,b,rad = linearRadial())
 surrogate_optimize(objective_function,SRBF(),a,b,my_rad_SRBF1,UniformSample())
 
 my_wend_1d = Wendland(x,y,lb,ub)
@@ -60,7 +60,7 @@ ub = [6.0,6.0]
 x = sample(5,lb,ub,SobolSample())
 objective_function_ND = z -> 3*norm(z)+1
 y = objective_function_ND.(x)
-my_rad_SRBFN = RadialBasis(x,y,lb,ub,rad = linearRadial)
+my_rad_SRBFN = RadialBasis(x,y,lb,ub,rad = linearRadial())
 surrogate_optimize(objective_function_ND,SRBF(),lb,ub,my_rad_SRBFN,UniformSample())
 
 # Lobachevsky
@@ -209,7 +209,7 @@ ub = 6.0
 my_k_DYCORS1 = Kriging(x,y,lb,ub,p=1.9)
 surrogate_optimize(objective_function,DYCORS(),lb,ub,my_k_DYCORS1,UniformSample())
 
-my_rad_DYCORS1 = RadialBasis(x,y,lb,ub,rad = linearRadial)
+my_rad_DYCORS1 = RadialBasis(x,y,lb,ub,rad = linearRadial())
 surrogate_optimize(objective_function,DYCORS(),lb,ub,my_rad_DYCORS1,UniformSample())
 
 
@@ -226,7 +226,7 @@ ub = [6.0,6.0]
 my_k_DYCORSN = Kriging(x,y,lb,ub)
 surrogate_optimize(objective_function_ND,DYCORS(),lb,ub,my_k_DYCORSN,UniformSample(),maxiters=30)
 
-my_rad_DYCORSN = RadialBasis(x,y,lb,ub,rad = linearRadial)
+my_rad_DYCORSN = RadialBasis(x,y,lb,ub,rad = linearRadial())
 surrogate_optimize(objective_function_ND,DYCORS(),lb,ub,my_rad_DYCORSN,UniformSample(),maxiters=30)
 
 my_wend_ND = Wendland(x,y,lb,ub)
@@ -264,7 +264,7 @@ lb = 1.0
 ub = 10.0
 x  = sample(100, lb, ub, SobolSample())
 y  = f.(x)
-my_radial_basis_smb = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_radial_basis_smb = RadialBasis(x, y, lb, ub, rad = linearRadial())
 surrogate_optimize(f,SMB(),lb,ub,my_radial_basis_ego,SobolSample())
 
 
@@ -274,7 +274,7 @@ lb = 1.0
 ub = 10.0
 x  = sample(100, lb, ub, SobolSample())
 y  = f.(x)
-my_radial_basis_rtea = RadialBasis(x, y, lb, ub, rad = linearRadial)
+my_radial_basis_rtea = RadialBasis(x, y, lb, ub, rad = linearRadial())
 Z = 0.8 #percentage
 K = 2 #number of revaluations
 p_cross = 0.5 #crossing vs copy


### PR DESCRIPTION
This changes the radial function API slightly from `RadialBasis(xs, ys, lb, ub, rad = multiquadricRadial)` to `rad = multiquadricRadial(c=1)`, where the default arg \epsilon is the shape parameter. To maintain consistency across all radial functions, 
`linearRadial -> linearRadial()` and so on. 