### PR TITLE
Input dimension checking when evaluating surrogates

### DIFF
--- a/lib/SurrogatesAbstractGPs/src/SurrogatesAbstractGPs.jl
+++ b/lib/SurrogatesAbstractGPs/src/SurrogatesAbstractGPs.jl
@@ -1,6 +1,6 @@
 module SurrogatesAbstractGPs
 
-import Surrogates: add_point!, AbstractSurrogate, std_error_at_point
+import Surrogates: add_point!, AbstractSurrogate, std_error_at_point, _check_dimension
 export AbstractGPSurrogate, var_at_point, logpdf_surrogate
 
 using AbstractGPs
@@ -18,14 +18,17 @@ function AbstractGPSurrogate(x, y; gp = GP(Matern52Kernel()), Σy = 0.1)
     AbstractGPSurrogate(x, y, gp, posterior(gp(x, Σy), y), Σy)
 end
 
-# predictor 
+# predictor
 function (g::AbstractGPSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(g, val)
+
     return only(mean(g.gp_posterior([val])))
 end
 
 # for add point
-# copies of x and y need to be made because we get 
-#"Error: cannot resize array with shared data " if we push! directly to x and y  
+# copies of x and y need to be made because we get
+#"Error: cannot resize array with shared data " if we push! directly to x and y
 function add_point!(g::AbstractGPSurrogate, new_x, new_y)
     if new_x in g.x
         println("Adding a sample that already exists, cannot build AbstracgGPSurrogate.")

--- a/lib/SurrogatesFlux/src/SurrogatesFlux.jl
+++ b/lib/SurrogatesFlux/src/SurrogatesFlux.jl
@@ -1,6 +1,6 @@
 module SurrogatesFlux
 
-import Surrogates: add_point!, AbstractSurrogate
+import Surrogates: add_point!, AbstractSurrogate, _check_dimension
 export NeuralSurrogate
 
 using Flux
@@ -37,6 +37,8 @@ function NeuralSurrogate(x, y, lb, ub; model = Chain(Dense(length(x[1]), 1), fir
 end
 
 function (my_neural::NeuralSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(my_neural, val)
     v = [val...]
     out = my_neural.model(v)
     if length(out) == 1

--- a/lib/SurrogatesPolyChaos/src/SurrogatesPolyChaos.jl
+++ b/lib/SurrogatesPolyChaos/src/SurrogatesPolyChaos.jl
@@ -1,6 +1,6 @@
 module SurrogatesPolyChaos
 
-import Surrogates: AbstractSurrogate, add_point!
+import Surrogates: AbstractSurrogate, add_point!, _check_dimension
 export PolynomialChaosSurrogate
 
 using PolyChaos
@@ -37,6 +37,9 @@ function PolynomialChaosSurrogate(x, y, lb::Number, ub::Number;
 end
 
 function (pc::PolynomialChaosSurrogate)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(pc, val)
+
     return sum([pc.coeff[i] * PolyChaos.evaluate(val, pc.ortopolys)[i]
                 for i in 1:(pc.num_of_multi_indexes)])
 end
@@ -71,6 +74,9 @@ function PolynomialChaosSurrogate(x, y, lb, ub;
 end
 
 function (pcND::PolynomialChaosSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(pcND, val)
+
     sum = zero(eltype(val[1]))
     for i in 1:(pcND.num_of_multi_indexes)
         sum = sum +

--- a/lib/SurrogatesRandomForest/src/SurrogatesRandomForest.jl
+++ b/lib/SurrogatesRandomForest/src/SurrogatesRandomForest.jl
@@ -1,6 +1,6 @@
 module SurrogatesRandomForest
 
-import Surrogates: add_point!, AbstractSurrogate
+import Surrogates: add_point!, AbstractSurrogate, _check_dimension
 export RandomForestSurrogate
 
 using XGBoost
@@ -19,6 +19,8 @@ function RandomForestSurrogate(x, y, lb::Number, ub::Number; num_round::Int = 1)
 end
 
 function (rndfor::RandomForestSurrogate)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(rndfor, val)
     return XGBoost.predict(rndfor.bst, reshape([val], 1, 1))[1]
 end
 
@@ -38,6 +40,8 @@ function RandomForestSurrogate(x, y, lb, ub; num_round::Int = 1)
 end
 
 function (rndfor::RandomForestSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(rndfor, val)
     return XGBoost.predict(rndfor.bst, reshape(collect(val), 1, length(val)))[1]
 end
 

--- a/src/Earth.jl
+++ b/src/Earth.jl
@@ -161,6 +161,8 @@ function EarthSurrogate(x, y, lb::Number, ub::Number; penalty::Number = 2.0,
 end
 
 function (earth::EarthSurrogate)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(earth, val)
     return sum([earth.coeff[i] * earth.basis[i](val) for i in 1:length(earth.coeff)]) +
            earth.intercept
 end
@@ -328,6 +330,8 @@ function EarthSurrogate(x, y, lb, ub; penalty::Number = 2.0, n_min_terms::Int = 
 end
 
 function (earth::EarthSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(earth, val)
     return sum([earth.coeff[i] * prod([earth.basis[i][j](val[j]) for j in 1:length(val)])
                 for i in 1:length(earth.coeff)]) + earth.intercept
 end

--- a/src/GEK.jl
+++ b/src/GEK.jl
@@ -54,6 +54,9 @@ function _calc_gek_coeffs(x, y, p::Number, theta::Number)
 end
 
 function std_error_at_point(k::GEK, val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(k, val)
+
     phi(z) = exp(-(abs(z))^k.p)
     nd1 = length(k.y)
     n = length(k.x)
@@ -75,6 +78,9 @@ function std_error_at_point(k::GEK, val::Number)
 end
 
 function (k::GEK)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(k, val)
+
     phi = z -> exp(-(abs(z))^k.p)
     n = length(k.x)
     prediction = zero(eltype(k.x[1]))
@@ -159,6 +165,10 @@ function _calc_gek_coeffs(x, y, p, theta)
 end
 
 function std_error_at_point(k::GEK, val)
+
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(k, val)
+
     nd1 = length(k.y)
     n = length(k.x)
     d = length(k.x[1])
@@ -184,6 +194,9 @@ function std_error_at_point(k::GEK, val)
 end
 
 function (k::GEK)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(k, val)
+
     d = length(val)
     n = length(k.x)
     return k.mu +

--- a/src/GEKPLS.jl
+++ b/src/GEKPLS.jl
@@ -63,9 +63,6 @@ end
 
 # predictor
 function (g::GEKPLS)(X_test)
-    # Check to make sure dimensions of input matches expected dimension of surrogate
-    _check_dimension(g, val)
-
     n_eval, n_features_x = size(X_test)
     X_cont = (X_test .- g.X_offset) ./ g.X_scale
     dx = differences(X_cont, g.X_after_std)

--- a/src/GEKPLS.jl
+++ b/src/GEKPLS.jl
@@ -61,8 +61,11 @@ function GEKPLS(X, y, grads, n_comp, delta_x, xlimits, extra_points, theta)
     println("struct created")
 end
 
-# predictor 
+# predictor
 function (g::GEKPLS)(X_test)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(g, val)
+
     n_eval, n_features_x = size(X_test)
     X_cont = (X_test .- g.X_offset) ./ g.X_scale
     dx = differences(X_cont, g.X_after_std)
@@ -124,7 +127,7 @@ function _ge_compute_pls(X, y, n_comp, grads, delta_x, xlimits, extra_points)
         X: Concatenation of XX: [extra_points*nt, dim] - Extra points added (when extra_points > 0) and X
         y: Concatenation of yy[extra_points*nt, 1]- Extra points added (when extra_points > 0) and y
         """
-    # this function is equivalent to a combination of 
+    # this function is equivalent to a combination of
     # https://github.com/SMTorg/smt/blob/f124c01ffa78c04b80221dded278a20123dac742/smt/utils/kriging_utils.py#L1036
     # and https://github.com/SMTorg/smt/blob/f124c01ffa78c04b80221dded278a20123dac742/smt/surrogate_models/gekpls.py#L48
 
@@ -180,7 +183,7 @@ end
 
 ######start of bbdesign######
 
-# 
+#
 # Adapted from 'ExperimentalDesign.jl: Design of Experiments in Julia'
 # https://github.com/phrb/ExperimentalDesign.jl
 
@@ -206,7 +209,7 @@ end
 # COPYRIGHT HOLDERS BE  LIABLE FOR ANY CLAIM, DAMAGES OR  OTHER LIABILITY, WHETHER
 # IN  AN ACTION  OF  CONTRACT, TORT  OR  OTHERWISE,  ARISING FROM,  OUT  OF OR  IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-# 
+#
 
 function boxbehnken(matrix_size::Int)
     boxbehnken(matrix_size, matrix_size)
@@ -259,7 +262,7 @@ end
 function standardization(X, y)
     """
     We substract the mean from each variable. Then, we divide the values of each
-    variable by its standard deviation. 
+    variable by its standard deviation.
 
     Parameters
     ----------
@@ -410,7 +413,7 @@ end
 
 function _reduced_likelihood_function(theta, kernel_type, d, nt, ij, y_norma, noise = 0.0)
     """
-    This function is a loose translation of SMT code from 
+    This function is a loose translation of SMT code from
     https://github.com/SMTorg/smt/blob/4a4df255b9259965439120091007f9852f41523e/smt/surrogate_models/krg_based.py#L247
     It  determines the BLUP parameters and evaluates the reduced likelihood function for the given theta.
 
@@ -428,7 +431,7 @@ function _reduced_likelihood_function(theta, kernel_type, d, nt, ij, y_norma, no
     Returns
     -------
     reduced_likelihood_function_value: real
-        - The value of the reduced likelihood function associated with the given autocorrelation parameters theta. 
+        - The value of the reduced likelihood function associated with the given autocorrelation parameters theta.
     beta:  Generalized least-squares regression weights
     gamma: Gaussian Process weights.
 
@@ -464,7 +467,7 @@ end
 
 ### MODIFIED PLS BELOW ###
 
-# The code below is a simplified version of 
+# The code below is a simplified version of
 # SKLearn's PLS
 # https://github.com/scikit-learn/scikit-learn/blob/80598905e/sklearn/cross_decomposition/_pls.py
 

--- a/src/InverseDistanceSurrogate.jl
+++ b/src/InverseDistanceSurrogate.jl
@@ -20,6 +20,9 @@ function InverseDistanceSurrogate(x, y, lb, ub; p::Number = 1.0)
 end
 
 function (inverSurr::InverseDistanceSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(inverSurr, val)
+
     if val in inverSurr.x
         return inverSurr.y[findfirst(x -> x == val, inverSurr.x)]
     else

--- a/src/Kriging.jl
+++ b/src/Kriging.jl
@@ -23,7 +23,7 @@ Gives the current estimate for array 'val' with respect to the Kriging object k.
 function (k::Kriging)(val)
 
     # Check to make sure dimensions of input matches expected dimension of surrogate
-   _check_dimension(k, val)
+    _check_dimension(k, val)
 
     n = length(k.x)
     d = length(val)

--- a/src/LinearSurrogate.jl
+++ b/src/LinearSurrogate.jl
@@ -51,6 +51,8 @@ function add_point!(my_linear::LinearSurrogate, new_x, new_y)
 end
 
 function (lin::LinearSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(lin, val)
     return lin.coeff' * [val...]
 end
 

--- a/src/Lobachevsky.jl
+++ b/src/Lobachevsky.jl
@@ -57,6 +57,9 @@ function LobachevskySurrogate(x, y, lb::Number, ub::Number; alpha::Number = 1.0,
 end
 
 function (loba::LobachevskySurrogate)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(loba, val)
+
     return sum(loba.coeff[j] * phi_nj1D(val, loba.x[j], loba.alpha, loba.n)
                for j in 1:length(loba.x))
 end
@@ -95,6 +98,8 @@ function LobachevskySurrogate(x, y, lb, ub; alpha = collect(one.(x[1])), n::Int 
 end
 
 function (loba::LobachevskySurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(loba, val)
     return sum(loba.coeff[j] * phi_njND(val, loba.x[j], loba.alpha, loba.n)
                for j in 1:length(loba.x))
 end

--- a/src/PolynomialChaos.jl
+++ b/src/PolynomialChaos.jl
@@ -32,6 +32,8 @@ function PolynomialChaosSurrogate(x, y, lb::Number, ub::Number;
 end
 
 function (pc::PolynomialChaosSurrogate)(val::Number)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(pc, val)
     return sum([pc.coeff[i] * PolyChaos.evaluate(val, pc.ortopolys)[i]
                 for i in 1:(pc.num_of_multi_indexes)])
 end
@@ -66,6 +68,8 @@ function PolynomialChaosSurrogate(x, y, lb, ub;
 end
 
 function (pcND::PolynomialChaosSurrogate)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(pcND, val)
     sum = zero(eltype(val[1]))
     for i in 1:(pcND.num_of_multi_indexes)
         sum = sum +

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -63,7 +63,7 @@ function _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
     if (typeof(y) == Vector{Float64}) #single output case
         coeff = copy(transpose(D \ y))
     else
-        coeff = copy(transpose(D \ Y[1:size(D)[1], :])) #if y is multi output; 
+        coeff = copy(transpose(D \ Y[1:size(D)[1], :])) #if y is multi output;
     end
     return coeff
 end
@@ -155,6 +155,9 @@ end
 Calculates current estimate of value 'val' with respect to the RadialBasis object.
 """
 function (rad::RadialBasis)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(rad, val)
+
     approx = _approx_rbf(val, rad)
     return _match_container(approx, first(rad.y))
 end
@@ -171,9 +174,11 @@ function _approx_rbf(val::Number, rad::R) where {R}
     end
     return approx
 end
+
 function _approx_rbf(val, rad::R) where {R}
     n = length(rad.x)
     d = length(rad.x[1])
+
     q = rad.dim_poly
     num_poly_terms = binomial(q + d, q)
     lb = rad.lb

--- a/src/SecondOrderPolynomialSurrogate.jl
+++ b/src/SecondOrderPolynomialSurrogate.jl
@@ -43,6 +43,10 @@ _construct_y_matrix(y, y_el::Number) = y
 _construct_y_matrix(y, y_el) = [y[i][j] for i in 1:length(y), j in 1:length(y_el)]
 
 function (my_second_ord::SecondOrderPolynomialSurrogate)(val)
+
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(my_second_ord, val)
+
     #just create the val vector as X and multiply
     d = length(val)
 

--- a/src/Wendland.jl
+++ b/src/Wendland.jl
@@ -50,6 +50,9 @@ function Wendland(x, y, lb, ub; eps = 1.0, maxiters = 300, tol = 1e-6)
 end
 
 function (wend::Wendland)(val)
+    # Check to make sure dimensions of input matches expected dimension of surrogate
+    _check_dimension(wend, val)
+
     return sum(wend.coeff[j] * _wendland(val, wend.eps) for j in 1:length(wend.coeff))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,3 +2,16 @@ remove_tracker(x) = x
 
 _match_container(y, y_el::Number) = first(y)
 _match_container(y, y_el) = y
+
+function _check_dimension(surr, input)
+    expected_dim = length(surr.x[1])
+    input_dim = length(input)
+
+    if input_dim != expected_dim
+        throw(
+            ArgumentError("This surrogate expects $expected_dim-dimensional inputs, but the input had dimension $input_dim.")
+        )
+    end
+
+    return nothing
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,8 +3,10 @@ remove_tracker(x) = x
 _match_container(y, y_el::Number) = first(y)
 _match_container(y, y_el) = y
 
+_expected_dimension(x) = length(x[1])
+
 function _check_dimension(surr, input)
-    expected_dim = length(surr.x[1])
+    expected_dim = _expected_dimension(surr.x)
     input_dim = length(input)
 
     if input_dim != expected_dim
@@ -12,6 +14,5 @@ function _check_dimension(surr, input)
             ArgumentError("This surrogate expects $expected_dim-dimensional inputs, but the input had dimension $input_dim.")
         )
     end
-
     return nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,9 +10,7 @@ function _check_dimension(surr, input)
     input_dim = length(input)
 
     if input_dim != expected_dim
-        throw(
-            ArgumentError("This surrogate expects $expected_dim-dimensional inputs, but the input had dimension $input_dim.")
-        )
+        throw(ArgumentError("This surrogate expects $expected_dim-dimensional inputs, but the input had dimension $input_dim."))
     end
     return nothing
 end

--- a/test/GEK.jl
+++ b/test/GEK.jl
@@ -20,7 +20,6 @@ add_point!(my_gek, 2.5, 2.5^2)
 @test_throws ArgumentError my_gek(Float64[])
 @test_throws ArgumentError my_gek((2.0, 3.0, 4.0))
 
-
 #ND
 n = 10
 d = 2

--- a/test/GEK.jl
+++ b/test/GEK.jl
@@ -16,6 +16,11 @@ val = my_gek(2.0)
 std_err = std_error_at_point(my_gek, 1.0)
 add_point!(my_gek, 2.5, 2.5^2)
 
+# Test that input dimension is properly checked for 1D GEK surrogates
+@test_throws ArgumentError my_gek(Float64[])
+@test_throws ArgumentError my_gek((2.0, 3.0, 4.0))
+
+
 #ND
 n = 10
 d = 2
@@ -43,3 +48,8 @@ my_gek_ND = GEK(x, y, lb, ub)
 val = my_gek_ND((1.0, 1.0))
 std_err = std_error_at_point(my_gek_ND, (1.0, 1.0))
 add_point!(my_gek_ND, (2.0, 2.0), 8.0)
+
+# Test that input dimension is properly checked for ND GEK surrogates
+@test_throws ArgumentError my_gek_ND(Float64[])
+@test_throws ArgumentError my_gek_ND(2.0)
+@test_throws ArgumentError my_gek_ND((2.0, 3.0, 4.0))

--- a/test/Kriging.jl
+++ b/test/Kriging.jl
@@ -11,13 +11,17 @@ x = sample(5, lb, ub, SobolSample())
 y = f.(x)
 my_p = 1.9
 
-# Check input validation for 1D Kriging
+# Check input validation for constructing 1D Kriging surrogates
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = -1.0)
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = 3.0)
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, theta = -2.0)
 
 my_k = Kriging(x, y, lb, ub, p = my_p)
 @test my_k.theta ≈ 0.5 * std(x)^(-my_p)
+
+# Check input dimension validation for 1D Kriging surrogates
+@test_throws ArgumentError my_k(rand(3))
+@test_throws ArgumentError my_k(Float64[])
 
 add_point!(my_k, 4.0, 75.68)
 add_point!(my_k, [5.0, 6.0], [238.86, 722.84])
@@ -108,11 +112,18 @@ std_err = std_error_at_point(my_k, (10.0, 11.0, 12.0))
 #test kwargs ND (hyperparameter initialization)
 kwarg_krig_ND = Kriging(x, y, lb, ub)
 
+# Check hyperparameter validation for ND kriging surrogate construction
 @test_throws ArgumentError Kriging(x, y, lb, ub, p = 3 * my_p)
 @test_throws ArgumentError Kriging(x, y, lb, ub, p = -my_p)
 @test_throws ArgumentError Kriging(x, y, lb, ub, theta = -my_theta)
 
-d = length(x[3])
+# Check input dimension validation for ND kriging surrogates
+@test_throws ArgumentError kwarg_krig_ND(1.0)
+@test_throws ArgumentError kwarg_krig_ND([1.0])
+@test_throws ArgumentError kwarg_krig_ND([2.0, 3.0])
+@test_throws ArgumentError kwarg_krig_ND(ones(5))
 
-@test all(==(2.0), kwarg_krig_ND.p)
-@test all(kwarg_krig_ND.theta .≈ [0.5 / var(x_i[ℓ] for x_i in x) for ℓ in 1:3])
+# Test hyperparameter initialization
+d = length(x[3])
+@test all(==(1), kwarg_krig_ND.p)
+@test all(kwarg_krig_ND.theta .≈ [0.5 / std(x_i[ℓ] for x_i in x)^1.99 for ℓ in 1:3])

--- a/test/Kriging.jl
+++ b/test/Kriging.jl
@@ -11,7 +11,7 @@ x = sample(5, lb, ub, SobolSample())
 y = f.(x)
 my_p = 1.9
 
-# Check input validation for constructing 1D Kriging surrogates
+# Check hyperparameter validation for constructing 1D Kriging surrogates
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = -1.0)
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = 3.0)
 @test_throws ArgumentError my_k=Kriging(x, y, lb, ub, theta = -2.0)
@@ -63,6 +63,11 @@ std_err = std_error_at_point(my_k, 4.0)
 
 #Testing kwargs 1D
 kwar_krig = Kriging(x, y, lb, ub);
+
+# Check hyperparameter initialization for 1D Kriging surrogates
+p_expected = 2.0
+@test kwar_krig.p == p_expected
+@test kwar_krig.theta == 0.5 / std(x)^p_expected
 
 #ND
 lb = [0.0, 0.0, 1.0]
@@ -125,5 +130,6 @@ kwarg_krig_ND = Kriging(x, y, lb, ub)
 
 # Test hyperparameter initialization
 d = length(x[3])
-@test all(==(1), kwarg_krig_ND.p)
-@test all(kwarg_krig_ND.theta .≈ [0.5 / std(x_i[ℓ] for x_i in x)^1.99 for ℓ in 1:3])
+p_expected = 2.0
+@test all(==(p_expected), kwarg_krig_ND.p)
+@test all(kwarg_krig_ND.theta .≈ [0.5 / std(x_i[ℓ] for x_i in x)^p_expected for ℓ in 1:3])

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -92,6 +92,10 @@ y = f.(x)
 my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
 @test my_radial_basis((1.0, 2.0)) ≈ 2
 
+# Test that input dimension is properly checked
+@test_throws ArgumentError my_radial_basis((1.0,))
+@test_throws ArgumentError my_radial_basis((2.0, 3.0, 4.0))
+
 # Multi-output
 f = x -> [x^2, x]
 lb = 1.0

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -27,6 +27,10 @@ my_rad = RadialBasis(x, y, lb, ub, rad = cubicRadial())
 q = 2
 my_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
 
+# Test that input dimension is properly checked for 1D radial surrogates
+@test_throws ArgumentError my_rad(Float64[])
+@test_throws ArgumentError my_rad((2.0, 3.0, 4.0))
+
 #ND
 x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
 y = [4.0, 5.0, 6.0]
@@ -92,7 +96,7 @@ y = f.(x)
 my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
 @test my_radial_basis((1.0, 2.0)) ≈ 2
 
-# Test that input dimension is properly checked
+# Test that input dimension is properly checked for ND radial surrogates
 @test_throws ArgumentError my_radial_basis((1.0,))
 @test_throws ArgumentError my_radial_basis((2.0, 3.0, 4.0))
 

--- a/test/Wendland.jl
+++ b/test/Wendland.jl
@@ -9,6 +9,10 @@ my_wend = Wendland(x, y, lb, ub)
 add_point!(my_wend, 0.5, 4.0)
 val = my_wend(0.5)
 
+# Test that input dimension is properly checked for 1D Wendland surrogates
+@test_throws ArgumentError my_wend(Float64[])
+@test_throws ArgumentError my_wend((2.0, 3.0, 4.0))
+
 #ND
 lb = [0.0, 0.0]
 ub = [4.0, 4.0]
@@ -19,4 +23,10 @@ my_wend_ND = Wendland(x, y, lb, ub)
 est = my_wend_ND((1.0, 2.0))
 add_point!(my_wend_ND, (3.0, 3.5), 4.0)
 add_point!(my_wend_ND, [(9.0, 10.0), (12.0, 13.0)], [10.0, 11.0])
+
+# Test that input dimension is properly checked for ND Wendland surrogates
+@test_throws ArgumentError my_wend_ND(Float64[])
+@test_throws ArgumentError my_wend_ND(2.0)
+@test_throws ArgumentError my_wend_ND((2.0, 3.0, 4.0))
+
 #todo

--- a/test/earth.jl
+++ b/test/earth.jl
@@ -11,6 +11,10 @@ my_ear1d = EarthSurrogate(x, y, lb, ub)
 val = my_ear1d(3.0)
 add_point!(my_ear1d, 6.0, 48.0)
 
+# Test that input dimension is properly checked for 1D Earth surrogates
+@test_throws ArgumentError my_ear1d(Float64[])
+@test_throws ArgumentError my_ear1d((2.0, 3.0, 4.0))
+
 #ND
 lb = [0.0, 0.0]
 ub = [10.0, 10.0]
@@ -21,3 +25,8 @@ y = f.(x)
 my_earnd = EarthSurrogate(x, y, lb, ub)
 val = my_earnd((2.0, 2.0))
 add_point!(my_earnd, (2.0, 2.0), 6.0)
+
+# Test that input dimension is properly checked for ND Earth surrogates
+@test_throws ArgumentError my_earnd(Float64[])
+@test_throws ArgumentError my_earnd(2.0)
+@test_throws ArgumentError my_earnd((2.0, 3.0, 4.0))

--- a/test/inverseDistanceSurrogate.jl
+++ b/test/inverseDistanceSurrogate.jl
@@ -14,6 +14,10 @@ prediction = InverseDistance(5.0)
 add_point!(InverseDistance, 5.0, -0.91)
 add_point!(InverseDistance, [5.1, 5.2], [1.0, 2.0])
 
+# Test that input dimension is properly checked for 1D inverse distance surrogates
+@test_throws ArgumentError InverseDistance(Float64[])
+@test_throws ArgumentError InverseDistance((2.0, 3.0, 4.0))
+
 #ND
 
 lb = [0.0, 0.0]
@@ -28,6 +32,11 @@ prediction = InverseDistance((1.0, 2.0))
 add_point!(InverseDistance, (5.0, 3.4), -0.91)
 add_point!(InverseDistance, [(5.1, 5.2), (5.3, 6.7)], [1.0, 2.0])
 
+# Test that input dimension is properly checked for 1D inverse distance surrogates
+@test_throws ArgumentError InverseDistance(Float64[])
+@test_throws ArgumentError InverseDistance(2.0)
+@test_throws ArgumentError InverseDistance((2.0, 3.0, 4.0))
+
 # Multi-output #98
 f = x -> [x^2, x]
 lb = 1.0
@@ -38,7 +47,6 @@ y = f.(x)
 surrogate = InverseDistanceSurrogate(x, y, lb, ub, p = 1.2)
 surrogate_kwargs = InverseDistanceSurrogate(x, y, lb, ub)
 @test surrogate(2.0) ≈ [4, 2]
-surrogate((0.0, 0.0))
 
 f = x -> [x[1], x[2]^2]
 lb = [1.0, 2.0]

--- a/test/linearSurrogate.jl
+++ b/test/linearSurrogate.jl
@@ -10,6 +10,10 @@ val = my_linear_surr_1D(5.0)
 add_point!(my_linear_surr_1D, 4.0, 7.2)
 add_point!(my_linear_surr_1D, [5.0, 6.0], [8.3, 9.7])
 
+# Test that input dimension is properly checked for 1D Linear surrogates
+@test_throws ArgumentError my_linear_surr_1D(Float64[])
+@test_throws ArgumentError my_linear_surr_1D((2.0, 3.0, 4.0))
+
 #ND
 lb = [0.0, 0.0]
 ub = [10.0, 10.0]
@@ -19,3 +23,8 @@ my_linear_ND = LinearSurrogate(x, y, lb, ub)
 add_point!(my_linear_ND, (10.0, 11.0), 9.0)
 add_point!(my_linear_ND, [(8.0, 5.0), (9.0, 9.5)], [4.0, 5.0])
 val = my_linear_ND((10.0, 11.0))
+
+# Test that input dimension is properly checked for ND Linear surrogates
+@test_throws ArgumentError my_linear_ND(Float64[])
+@test_throws ArgumentError my_linear_ND(1.0)
+@test_throws ArgumentError my_linear_ND((2.0, 3.0, 4.0))

--- a/test/lobachevsky.jl
+++ b/test/lobachevsky.jl
@@ -15,6 +15,10 @@ n = 6
 my_loba = LobachevskySurrogate(x, y, a, b, alpha = 2.0, n = 6)
 val = my_loba(3.83)
 
+# Test that input dimension is properly checked for 1D Lobachevsky surrogates
+@test_throws ArgumentError my_loba(Float64[])
+@test_throws ArgumentError my_loba((2.0, 3.0, 4.0))
+
 #1D integral
 int_1D = lobachevsky_integral(my_loba, a, b)
 int = quadgk(obj, a, b)
@@ -35,6 +39,12 @@ y = obj.(x)
 my_loba_ND = LobachevskySurrogate(x, y, lb, ub, alpha = [2.4, 2.4], n = 8)
 my_loba_kwargs = LobachevskySurrogate(x, y, lb, ub)
 pred = my_loba_ND((1.0, 2.0))
+
+# Test that input dimension is properly checked for ND Lobachevsky surrogates
+@test_throws ArgumentError my_loba_ND(Float64[])
+@test_throws ArgumentError my_loba_ND(1.0)
+@test_throws ArgumentError my_loba_ND((2.0, 3.0, 4.0))
+
 #ND
 
 int_ND = lobachevsky_integral(my_loba_ND, lb, ub)

--- a/test/secondOrderPolynomialSurrogate.jl
+++ b/test/secondOrderPolynomialSurrogate.jl
@@ -12,6 +12,10 @@ val = my_second_order_poly(5.0)
 add_point!(my_second_order_poly, 5.0, 238.86)
 add_point!(my_second_order_poly, [6.0, 7.0], [722.84, 2133.94])
 
+# Test that input dimension is properly checked for 1D SecondOrderPolynomial surrogates
+@test_throws ArgumentError my_second_order_poly(Float64[])
+@test_throws ArgumentError my_second_order_poly((2.0, 3.0, 4.0))
+
 #ND
 lb = [0.0, 0.0]
 ub = [10.0, 10.0]
@@ -22,6 +26,11 @@ my_second_order_poly = SecondOrderPolynomialSurrogate(x, y, lb, ub)
 val = my_second_order_poly((5.0, 7.0))
 add_point!(my_second_order_poly, (5.0, 7.0), 1764.96)
 add_point!(my_second_order_poly, [(1.5, 1.5), (3.4, 5.4)], [1.817, 270.95])
+
+# Test that input dimension is properly checked for ND SecondOrderPolynomial surrogates
+@test_throws ArgumentError my_second_order_poly(Float64[])
+@test_throws ArgumentError my_second_order_poly(2.0)
+@test_throws ArgumentError my_second_order_poly((2.0, 3.0, 4.0))
 
 # Multi-output #98
 f = x -> [x^2, x]


### PR DESCRIPTION
Fixes https://github.com/SciML/Surrogates.jl/issues/337. Adds a new utility function `_check_input_dimension` which is called for all surrogates before evaluating a point. Provides a helpful error message if there's a dimension mismatch. 

# Example

```julia
using Surrogates

lb = 0.0
ub = 4.0
x = [1.0,2.0,3.0]
y = [4.0,5.0,6.0]
my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial())
```

```julia
julia> my_rad(Float64[1.5])
4.5

julia> my_rad([1.0, 2.0])
ERROR: ArgumentError: This surrogate expects 1-dimensional inputs, but the input had dimension 2.
Stacktrace:
 [1] _check_dimension
   @ C:\Users\thoma\Surrogates.jl\src\utils.jl:11 [inlined]
 [2] (::RadialBasis{Surrogates.var"#1#2", Int64, Vector{Float64}, Vector{Float64}, Float64, Float64, Transpose{Float64, Vector{Float64}}, Float64, Bool})(val::Vector{Float64})
   @ Surrogates C:\Users\thoma\Surrogates.jl\src\Radials.jl:159
 [3] top-level scope
   @ REPL[39]:1

julia> my_rad(Float64[])
ERROR: ArgumentError: This surrogate expects 1-dimensional inputs, but the input had dimension 0.
Stacktrace:
 [1] _check_dimension
   @ C:\Users\thoma\Surrogates.jl\src\utils.jl:11 [inlined]
 [2] (::RadialBasis{Surrogates.var"#1#2", Int64, Vector{Float64}, Vector{Float64}, Float64, Float64, Transpose{Float64, Vector{Float64}}, Float64, Bool})(val::Vector{Float64})
   @ Surrogates C:\Users\thoma\Surrogates.jl\src\Radials.jl:159
 [3] top-level scope
   @ REPL[40]:1
```

Benchmarking reveals this to come at a very small cost:

**Before**
julia> @benchmark my_rad([1.5])
BenchmarkTools.Trial: 10000 samples with 855 evaluations.
 Range (min … max):  143.392 ns …  10.876 μs  ┊ GC (min … max): 0.00% … 97.94%
 Time  (median):     146.784 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   175.408 ns ± 332.221 ns  ┊ GC (mean ± σ):  7.69% ±  4.01%

  ▆█▆▅▄▂▁                                   ▁  ▂▄▄▂    ▁        ▁
  ████████▆▆▇▅▅▅▆▅▅▅▄▅▆▅▄▄▃▅▅▅▅▅▅▅▅▄▄▅▅▅▅▄▇█████████▇▆██▇▆▅▄▅▄▄ █
  143 ns        Histogram: log(frequency) by time        247 ns <

 Memory estimate: 144 bytes, allocs estimate: 3.

**After**
julia> @benchmark my_rad([1.5])
BenchmarkTools.Trial: 10000 samples with 825 evaluations.
 Range (min … max):  151.394 ns …  10.147 μs  ┊ GC (min … max): 0.00% … 97.38%
 Time  (median):     155.394 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   196.150 ns ± 340.000 ns  ┊ GC (mean ± σ):  6.83% ±  3.89%

  ▇█▄▃▂▂                       ▁▁▁  ▂▄▅▅▂▁▁▂                    ▁
  ████████▇▆▅▆▇▇▇▆▆▇▆▇▆▆▆▆▆▅▅▅▇██████████████▆▄▅▅▄▅▆▅▅▆▆▅▆▄▃▅▄▄ █
  151 ns        Histogram: log(frequency) by time        302 ns <

 Memory estimate: 144 bytes, allocs estimate: 3.