### PR TITLE
More Kriging improvements (log likelihood, noise variance, more tests)

### DIFF
--- a/src/LinearSurrogate.jl
+++ b/src/LinearSurrogate.jl
@@ -74,6 +74,7 @@ function LinearSurrogate(x, y, lb, ub)
     #T = transpose(reshape(reinterpret(eltype(x[1]), x), length(x[1]), length(x)))
     X = Array{eltype(x[1]), 2}(undef, length(x), length(x[1]))
     X = copy(T)
+
     ols = lm(X, y)
     return LinearSurrogate(x, y, coef(ols), lb, ub)
 end

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -26,7 +26,7 @@ multiquadricRadial(c = 1.0) = RadialFunction(1, z -> sqrt((c * norm(z))^2 + 1))
 
 thinplateRadial() = RadialFunction(2, z -> begin
                                        result = norm(z)^2 * log(norm(z))
-                                       ifelse(iszero(z), zero(result), result)
+                                       ifelse(all(==(0), z), zero(result), result)
                                    end)
 
 """

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -6,8 +6,9 @@ using QuasiMonteCarlo: SamplingAlgorithm
 # of vectors of Tuples
 function sample(args...; kwargs...)
     s = QuasiMonteCarlo.sample(args...; kwargs...)
-    if s isa Vector
-        # 1D case: s is a Vector
+    if size(s, 1) == 1
+        return s[1, :]
+    elseif size(s, 2) == 1
         return s
     else
         # ND case: s is a d x n matrix, where d is the dimension and n is the number of samples

--- a/test/AD_compatibility.jl
+++ b/test/AD_compatibility.jl
@@ -122,7 +122,7 @@ end
 
     # test gradient with respect to hyperparameters
     obj = ((p, θ),) -> Surrogates.kriging_log_likelihood(x, y, p, θ)
-    obj'((1.99, 1.0),)
+    obj'((1.99, 1.0))
 end
 
 # #Linear Surrogate

--- a/test/AD_compatibility.jl
+++ b/test/AD_compatibility.jl
@@ -114,10 +114,15 @@ end
 
 # #Kriging
 @testset "Kriging 1D" begin
+    # Test gradient of surrogate evaluation
     my_p = 1.5
     my_krig = Kriging(x, y, lb, ub, p = my_p)
     g = x -> my_krig'(x)
     g(5.0)
+
+    # test gradient with respect to hyperparameters
+    obj = ((p, θ),) -> Surrogates.kriging_log_likelihood(x, y, p, θ)
+    obj'((1.99, 1.0),)
 end
 
 # #Linear Surrogate
@@ -202,6 +207,10 @@ end
     my_krig = Kriging(x, y, lb, ub, p = my_p, theta = my_theta)
     g = x -> Zygote.gradient(my_krig, x)
     g((2.0, 5.0))
+
+    # test gradient with respect to hyperparameters
+    obj = params -> Surrogates.kriging_log_likelihood(x, y, params[1:2], params[3:4])
+    obj'([1.9, 1.9, 2.0, 2.0])
 end
 
 # Linear Surrogate

--- a/test/Kriging.jl
+++ b/test/Kriging.jl
@@ -24,8 +24,6 @@ my_k = Kriging(x, y, lb, ub, p = my_p)
 # Check to make sure interpolation condition is satisfied
 @test _check_interpolation(my_k)
 
-
-
 # Check input dimension validation for 1D Kriging surrogates
 @test_throws ArgumentError my_k(rand(3))
 @test_throws ArgumentError my_k(Float64[])

--- a/test/Kriging.jl
+++ b/test/Kriging.jl
@@ -3,6 +3,8 @@ using Surrogates
 using Test
 using Statistics
 
+include("test_utils.jl")
+
 #1D
 lb = 0.0
 ub = 10.0
@@ -18,6 +20,11 @@ my_p = 1.9
 
 my_k = Kriging(x, y, lb, ub, p = my_p)
 @test my_k.theta ≈ 0.5 * std(x)^(-my_p)
+
+# Check to make sure interpolation condition is satisfied
+@test _check_interpolation(my_k)
+
+
 
 # Check input dimension validation for 1D Kriging surrogates
 @test_throws ArgumentError my_k(rand(3))
@@ -65,7 +72,7 @@ std_err = std_error_at_point(my_k, 4.0)
 kwar_krig = Kriging(x, y, lb, ub);
 
 # Check hyperparameter initialization for 1D Kriging surrogates
-p_expected = 2.0
+p_expected = 1.99
 @test kwar_krig.p == p_expected
 @test kwar_krig.theta == 0.5 / std(x)^p_expected
 
@@ -130,6 +137,18 @@ kwarg_krig_ND = Kriging(x, y, lb, ub)
 
 # Test hyperparameter initialization
 d = length(x[3])
-p_expected = 2.0
+p_expected = 1.99
 @test all(==(p_expected), kwarg_krig_ND.p)
 @test all(kwarg_krig_ND.theta .≈ [0.5 / std(x_i[ℓ] for x_i in x)^p_expected for ℓ in 1:3])
+
+num_replicates = 100
+
+for i in 1:num_replicates
+    # Check that interpolation condition is satisfied when noise variance is zero
+    surr = _random_surrogate(Kriging)
+    @test _check_interpolation(surr)
+
+    # Check that we do not satisfy interpolation condition when noise variance isn't zero
+    surr = _random_surrogate(Kriging, noise_variance = 0.2)
+    @test !_check_interpolation(surr)
+end

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -174,3 +174,13 @@ y = mockvalues.(x)
 rbf = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(1.788))
 test = (lb .+ ub) ./ 2
 @test isapprox(rbf(test), mockvalues(test), atol = 0.001)
+
+num_replicates = 100
+
+for radial_type in [linearRadial(), cubicRadial(), multiquadricRadial(), thinplateRadial()]
+    for i in 1:num_replicates
+        # Check that interpolation condition is satisfied
+        surr = _random_surrogate(RadialBasis, rad = radial_type)
+        @test _check_interpolation(surr)
+    end
+end

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -3,6 +3,8 @@ using Test
 using LinearAlgebra
 using Surrogates
 
+include("test_utils.jl")
+
 #1D
 lb = 0.0
 ub = 4.0

--- a/test/Wendland.jl
+++ b/test/Wendland.jl
@@ -1,4 +1,7 @@
 using Surrogates
+using LinearAlgebra
+
+include("test_utils.jl")
 
 #1D
 x = [1.0, 2.0, 3.0]

--- a/test/inverseDistanceSurrogate.jl
+++ b/test/inverseDistanceSurrogate.jl
@@ -62,3 +62,10 @@ y_new = f(x_new)
 add_point!(surrogate, x_new, y_new)
 @test surrogate(x_new) ≈ y_new
 surrogate((0.0, 0.0))
+
+num_replicates = 100
+for i in 1:num_replicates
+    # Check that interpolation condition is satisfied
+    surr = _random_surrogate(InverseDistanceSurrogate)
+    @test _check_interpolation(surr)
+end

--- a/test/inverseDistanceSurrogate.jl
+++ b/test/inverseDistanceSurrogate.jl
@@ -1,5 +1,8 @@
 using Surrogates
 using Test
+using LinearAlgebra
+
+include("test_utils.jl")
 
 #1D
 obj = x -> sin(x) + sin(x)^2 + sin(x)^3

--- a/test/linearSurrogate.jl
+++ b/test/linearSurrogate.jl
@@ -28,3 +28,14 @@ val = my_linear_ND((10.0, 11.0))
 @test_throws ArgumentError my_linear_ND(Float64[])
 @test_throws ArgumentError my_linear_ND(1.0)
 @test_throws ArgumentError my_linear_ND((2.0, 3.0, 4.0))
+
+num_replicates = 100
+for i in 1:num_replicates
+    # LinearSurrogate should not interpolate the data unless the data/func is linear
+    surr = _random_surrogate(LinearSurrogate)
+    @test !_check_interpolation(surr)
+
+    linear_func = x -> sum(x)
+    surr = _random_surrogate(LinearSurrogate, linear_func)
+    @test _check_interpolation(surr)
+end

--- a/test/linearSurrogate.jl
+++ b/test/linearSurrogate.jl
@@ -1,5 +1,7 @@
 using Surrogates
 
+include("test_utils.jl")
+
 #1D
 x = [1.0, 2.0, 3.0]
 y = [1.5, 3.5, 5.3]

--- a/test/lobachevsky.jl
+++ b/test/lobachevsky.jl
@@ -4,6 +4,8 @@ using Test
 using QuadGK
 using Cubature
 
+include("test_utils.jl")
+
 #1D
 obj = x -> 3 * x + log(x)
 a = 1.0

--- a/test/lobachevsky.jl
+++ b/test/lobachevsky.jl
@@ -85,3 +85,10 @@ n = 8
 x = sample(100, lb, ub, SobolSample())
 y = obj.(x)
 my_loba_ND = LobachevskySurrogate(x, y, lb, ub, alpha = [2.4, 2.4], n = 8, sparse = true)
+
+num_replicates = 100
+for i in 1:num_replicates
+    # Check that interpolation condition is satisfied
+    surr = _random_surrogate(LobachevskySurrogate)
+    @test _check_interpolation(surr)
+end

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -63,6 +63,13 @@ s = Surrogates.sample(n, lb, ub, SectionSample([constrained_val], UniformSample(
 @test s isa Vector{Float64} && length(s) == n && all(x -> lb ≤ x ≤ ub, s)
 @test all(==(constrained_val), s)
 
+# ND but 1D
+
+lb = [0.0]
+ub = [5.0]
+s = Surrogates.sample(n, lb, ub, SobolSample())
+@test s isa Vector{Float64} && length(s) == n && all(x -> lb[1] ≤ x ≤ ub[1], s)
+
 # ND
 # Now that we use QuasiMonteCarlo.jl, these tests are to make sure that we transform the output
 # from a Matrix to a Vector of Tuples properly for ND problems.

--- a/test/secondOrderPolynomialSurrogate.jl
+++ b/test/secondOrderPolynomialSurrogate.jl
@@ -1,6 +1,8 @@
 using Surrogates
 using Test
 
+include("test_utils.jl")
+
 #1D
 lb = 0.0
 ub = 5.0

--- a/test/secondOrderPolynomialSurrogate.jl
+++ b/test/secondOrderPolynomialSurrogate.jl
@@ -73,3 +73,15 @@ x = sample(n, lb, ub, SobolSample())
 y = second_order_target.(x)
 sec = SecondOrderPolynomialSurrogate(x, y, lb, ub)
 @test y ≈ sec.(x)
+
+num_replicates = 100
+for i in 1:num_replicates
+    # Second order polynomial surrogate should not intepolate the data unless the function
+    # is a second-order polynomial
+    surr = _random_surrogate(SecondOrderPolynomialSurrogate)
+    @test !_check_interpolation(surr)
+
+    # Norm squared is a second order polynomial so this should interpolate the data
+    surr = _random_surrogate(SecondOrderPolynomialSurrogate, x->norm(x)^2)
+    @test _check_interpolation(surr)
+end

--- a/test/secondOrderPolynomialSurrogate.jl
+++ b/test/secondOrderPolynomialSurrogate.jl
@@ -82,6 +82,6 @@ for i in 1:num_replicates
     @test !_check_interpolation(surr)
 
     # Norm squared is a second order polynomial so this should interpolate the data
-    surr = _random_surrogate(SecondOrderPolynomialSurrogate, x->norm(x)^2)
+    surr = _random_surrogate(SecondOrderPolynomialSurrogate, x -> norm(x)^2)
     @test _check_interpolation(surr)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -3,7 +3,6 @@ Properties that surrogates should typically satisfy:
 
 1) Interpolate the data
 
-
 =#
 
 # Check that surrogate correctly interpolates data
@@ -18,7 +17,6 @@ end
 # Generate a surrogate of the provided type with a random dimension and number of points
 # By default, the function to be modeled is the l2-norm function
 function _random_surrogate(surr_type, func = norm, sampler = SobolSample(); kwargs...)
-
     d = rand(1:10)
     n = rand(1:3) * 10 * d + 1
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,38 @@
+#=
+Properties that surrogates should typically satisfy:
+
+1) Interpolate the data
+
+
+=#
+
+# Check that surrogate correctly interpolates data
+function _check_interpolation(surr; tol = sqrt(eps(Float64)))
+    N = length(surr.y)
+    pred = surr.(surr.x)
+    errs = abs.(pred .- surr.y)
+    mean_abs_err = sum(errs) / N
+    return mean_abs_err ≤ tol
+end
+
+# Generate a surrogate of the provided type with a random dimension and number of points
+# By default, the function to be modeled is the l2-norm function
+function _random_surrogate(surr_type, func = norm, sampler = SobolSample(); kwargs...)
+
+    d = rand(1:10)
+    n = rand(1:3) * 10 * d + 1
+
+    if d == 1
+        lb = -2.0
+        ub = 2.0
+    else
+        lb = -2 * ones(d)
+        ub = 2 * ones(d)
+    end
+
+    x = Surrogates.sample(n, lb, ub, sampler)
+    y = func.(x)
+
+    surr = surr_type(x, y, lb, ub; kwargs...)
+    return surr
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra
+
 #=
 Properties that surrogates should typically satisfy:
 


### PR DESCRIPTION
This addresses https://github.com/SciML/Surrogates.jl/issues/375 as well as adds some more testing utilities to move us toward more rigorous and comprehensive property-based testing of surrogates.

## 1. Noise variance

The `Kriging` object now has a new field, `noise_variance`, which defaults to zero. This is a number added to the main diagonal of the covariance matrix which allows Kriging to model noisy functions

Here's what including noise variance looks like:

```julia
Random.seed!(1234)
  lb = 0.0
  ub = 10.0
  func = x -> sin(x)
  n_samples = 50
  x = sample(n_samples, lb, ub, SobolSample())

  # Add some random noise to the function
  y = func.(x) .+ 0.1 * randn(n_samples)

  # Build a kriging surrogate without noise
  my_k = Kriging(x, y, lb, ub, noise_variance = 0.0)

  x_fine = LinRange(lb, ub, 10000)
  y_fine = func.(x_fine)
  pred_fine = my_k.(x_fine)
  errs = std_error_at_point.(my_k, x_fine)
  p = Plots.plot(x_fine, y_fine, label = "True function", legend = :outertop)
  Plots.plot!(x_fine, pred_fine, label = "surrogate", ribbon= 3 * errs, ylims = (-2, 2))
  Plots.scatter!(my_k.x, my_k.y, mc = :black, label = "Data")
```
![plot_258](https://user-images.githubusercontent.com/60799002/178525448-a263e4be-3e64-4235-a4c2-fa2bcee6b2c0.png)

This interpolates the data but doesn't tell us much about how the signal varies

If we now instead include a noise variance, we get a much more accurate picture of the underlying function

```julia
my_k = Kriging(x, y, lb, ub, noise_variance = 0.1)
```

![plot_257](https://user-images.githubusercontent.com/60799002/178525783-59cd9c5d-54a7-4b41-a805-f96e501705e5.png)


## 2. Log likelihood function for kriging

There is now a `Surrogates.kriging_log_likelihood(x, y, p, theta, noise_variance)` function which is differentiable and can be used for hyperparameter optimization. 

## 3. Property-based testing

I have created a new file, `test_utils.jl` with two functions: `_random_surrogate` and `_check_interpolation`. The first generates a random surrogate (random dimension, number of points) of the given type and optionally using a provided function. The second checks that the input surrogate correctly interpolates its input data. Interpolation is an important property to check for most surrogates, and in cases when the surrogate regresses rather than interpolates (kriging with noise_variance not equal to zero, `linearSurrogate`, `SecondOrderPolynomialSurrogate`), we can check that that behavior also holds. I have added interpolation-checking tests to all surrogates except for Wendland, GEK, GEKPLS, and Earth. In testing, I found that Wendland doesn't seem to work at all, so that should be fixed.

## 4. Miscellaneous

I changed Kriging's default `p` from 2.0 to 1.99 to help numerical stability

## Still to do

- [ ] Add examples for kriging hyperparameter optimization to docs
- [ ] Add example for kriging noise variance to docs
- [ ] Fix Wendland surrogate
- [ ] Many doc examples are broken, would be good to fix those.