### PR TITLE
Speed up radial basis functions when output is single number

### DIFF
--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -164,10 +164,6 @@ end
 
 function _approx_rbf(val::Number, rad::R) where {R}
     n = length(rad.x)
-    q = rad.dim_poly
-    num_poly_terms = binomial(q + 1, q)
-    lb = rad.lb
-    ub = rad.ub
     approx = zero(rad.coeff[:, 1])
     for i in 1:n
         approx += rad.coeff[:, i] * rad.phi((val .- rad.x[i]) / rad.scale_factor)
@@ -177,15 +173,6 @@ end
 
 function _approx_rbf(val, rad::R) where {R}
     n = length(rad.x)
-    d = length(rad.x[1])
-
-    q = rad.dim_poly
-    num_poly_terms = binomial(q + d, q)
-    lb = rad.lb
-    ub = rad.ub
-    sum_half_diameter = sum((ub[k] - lb[k]) / 2 for k in 1:d)
-    mean_half_diameter = sum_half_diameter / d
-    central_point = _center_bounds(first(rad.x), lb, ub)
 
     l = size(rad.coeff, 1)
     approx = Buffer(zeros(eltype(val), l), false)

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -175,7 +175,7 @@ end
 function _add_tmp_to_approx!(approx::Base.RefValue, i, tmp,
                              rad::RadialBasis{F, Q, X, <:AbstractArray{<:Number}};
                              f = identity) where {F, Q, X}
-    @inbounds @simd ivdep for j in 1:1 # i have no idea why but like this it's crazy fast
+    @inbounds @simd ivdep for j in 1:size(rad.coeff, 1)
         approx[] += rad.coeff[j, i] * f(tmp)
     end
 end
@@ -185,6 +185,11 @@ _ret_copy(v) = copy(v)
 
 function _approx_rbf(val, rad::RadialBasis)
     n = length(rad.x)
+
+    # make sure @inbounds is safe
+    if n > size(rad.coeff, 2)
+        throw("Length of model's x vector exceeds number of calculated coefficients ($n != $(size(rad.coeff, 2))).")
+    end
 
     approx = _make_approx(val, rad)
 

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -160,18 +160,21 @@ end
 
 function _make_approx(val, rad::RadialBasis)
     l = size(rad.coeff, 1)
-    Buffer(zeros(eltype(val), l), false)
+    return Buffer(zeros(eltype(val), l), false)
 end
-function _add_tmp_to_approx!(approx, i, tmp, rad::RadialBasis; f=identity)
+function _add_tmp_to_approx!(approx, i, tmp, rad::RadialBasis; f = identity)
     @inbounds @simd ivdep for j in 1:size(rad.coeff, 1)
         approx[j] += rad.coeff[j, i] * f(tmp)
     end
 end
 # specialise when only single output dimension
-function _make_approx(val, ::RadialBasis{F, Q, X, <:AbstractArray{<:Number}}) where {F, Q, X}
-    Ref(zero(eltype(val)))
+function _make_approx(val,
+                      ::RadialBasis{F, Q, X, <:AbstractArray{<:Number}}) where {F, Q, X}
+    return Ref(zero(eltype(val)))
 end
-function _add_tmp_to_approx!(approx::Base.RefValue, i, tmp, rad::RadialBasis{F, Q, X, <:AbstractArray{<:Number}}; f=identity) where {F, Q, X}
+function _add_tmp_to_approx!(approx::Base.RefValue, i, tmp,
+                             rad::RadialBasis{F, Q, X, <:AbstractArray{<:Number}};
+                             f = identity) where {F, Q, X}
     @inbounds @simd ivdep for j in 1:1 # i have no idea why but like this it's crazy fast
         approx[] += rad.coeff[j, i] * f(tmp)
     end

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -30,19 +30,6 @@ thinplateRadial() = RadialFunction(2, z -> begin
                                    end)
 
 """
-    RadialBasis(x,y,lb::Number,ub::Number; rad::RadialFunction = linearRadial(),scale::Real=1.0)
-
-Constructor for RadialBasis surrogate.
-"""
-function RadialBasis(x, y, lb::Number, ub::Number; rad::RadialFunction = linearRadial(),
-                     scale_factor::Real = 0.5, sparse = false)
-    q = rad.q
-    phi = rad.phi
-    coeff = _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse)
-    return RadialBasis(phi, q, x, y, lb, ub, coeff, scale_factor, sparse)
-end
-
-"""
 RadialBasis(x,y,lb,ub,rad::RadialFunction, scale_factor::Float = 1.0)
 
 Constructor for RadialBasis surrogate
@@ -162,7 +149,7 @@ function (rad::RadialBasis)(val)
     return _match_container(approx, first(rad.y))
 end
 
-function _approx_rbf(val::Number, rad::R) where {R}
+function _approx_rbf(val::Number, rad::RadialBasis)
     n = length(rad.x)
     approx = zero(rad.coeff[:, 1])
     for i in 1:n
@@ -171,7 +158,7 @@ function _approx_rbf(val::Number, rad::R) where {R}
     return approx
 end
 
-function _approx_rbf(val, rad::R) where {R}
+function _approx_rbf(val, rad::RadialBasis)
     n = length(rad.x)
 
     l = size(rad.coeff, 1)


### PR DESCRIPTION
I added a few function calls in `_approx_rbf` that dispatch on `::RadialBasis{F,Q,X,<:AbstractArray{<:Number}}` -- a type that restricts the output to just a number.

Doing this lets us elide creating an output buffer, which means RBFs are now allocation-free when the output is a single dimension.

The motivation behind this is specific to my use-case (creating surrogates of old Fortran spectral models to use in MCMC fitting), but I hope others may find this useful too.

Using an example from the docs:
```julia
using Surrogates
using BenchmarkTools

function booth(x)
    x1=x[1]
    x2=x[2]
    term1 = (x1 + 2*x2 - 7)^2;
    term2 = (2*x1 + x2 - 5)^2;
    y = term1 + term2;
end

n_samples = 80
lower_bound = [-5.0, 0.0]
upper_bound = [10.0, 15.0]

xys = sample(n_samples, lower_bound, upper_bound, SobolSample())
zs = booth.(xys)

radial_basis = RadialBasis(xys, zs,  lower_bound, upper_bound)

# new sample space
xys = sample(500, lower_bound, upper_bound, SobolSample())

function benchmarktest(radial_basis, xys)
    s = 0.0
    for v in xys
        s += radial_basis(v)
    end
    s
end

@btime benchmarktest($radial_basis, $xys)
# before: 253.122 μs (500 allocations: 31.25 KiB)
# after: 166.757 μs (0 allocations: 0 bytes)
```

I also added a few `@inbound` annotations to squeeze a bit more performance, since `_check_dimension` already ensures things are pretty good:

```julia
@btime benchmarktest($radial_basis, $xys)
# after + @inbounds 57.860 μs (0 allocations: 0 bytes)
```

Overall, the result is a 4-5x speedup, with all the RBF test cases still passing (at least on my machine), and inspecting invocations with `@code_warntype` shows the methods to be type-stable.

Let me know if this is alright, or if there's anything else I can do! Also any feedback or alternative suggestions on the implementation would be welcomed :) I would have used `@generated` for this but I know that can be a bit controversial.

Cheers!