### PR TITLE
fix: `master` branch is failing precompilation

### DIFF
--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -34,9 +34,9 @@ RadialBasis(x,y,lb,ub,rad::RadialFunction, scale_factor::Float = 1.0)
 
 Constructor for RadialBasis surrogate, of the form
 
-$$f(x) = \sum_{i=1}^{N} w_i \phi(|x - \bold{c}_i|) \bold{v}^{T} + \bold{v}^{\mathrm{T}} [ 0; \bold{x} ]$$
+``f(x) = \\sum_{i=1}^{N} w_i \\phi(|x - \\bold{c}_i|) \\bold{v}^{T} + \\bold{v}^{\\mathrm{T}} [ 0; \\bold{x} ]``
 
-where $w_i$ are the weights of polyharmonic splines $$\phi(x)$$ and $$\bold{v}$$ are coefficients
+where ``w_i`` are the weights of polyharmonic splines ``\\phi(x)`` and ``\\bold{v}`` are coefficients
 of a polynomial term.
 
 References:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Surrogates
 using Test
 using SafeTestsets
 using Pkg
-Pkg.add(name="Statistics", version=VERSION)
+VERSION <= v"1.7" && Pkg.add(name="Statistics", version=VERSION)
 
 function dev_subpkg(subpkg)
     subpkg_path = joinpath(dirname(@__DIR__), "lib", subpkg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Surrogates
 using Test
 using SafeTestsets
 using Pkg
+Pkg.add(name="Statistics", version=VERSION)
 
 function dev_subpkg(subpkg)
     subpkg_path = joinpath(dirname(@__DIR__), "lib", subpkg)


### PR DESCRIPTION
Getting an error:

```julia
julia> using Surrogates
[ Info: Precompiling Surrogates [6fc51010-71bc-11e9-0e15-a3fcc6593c49]
ERROR: LoadError: syntax: invalid interpolation syntax: "$$"
Stacktrace:
 [1] top-level scope
   @ ~/oss/Surrogates.jl/src/Radials.jl:37
 [2] include(mod::Module, _path::String)
   @ Base ./Base.jl:457
 [3] include(x::String)
   @ Surrogates ~/oss/Surrogates.jl/src/Surrogates.jl:1
 [4] top-level scope
   @ ~/oss/Surrogates.jl/src/Surrogates.jl:7
 [5] include
   @ ./Base.jl:457 [inlined]
 [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
   @ Base ./loading.jl:2049
 [7] top-level scope
   @ stdin:3
```

Same error in the CI build on master - https://github.com/SciML/Surrogates.jl/actions/runs/5554601185/job/15046314727

This should fix that

