### PR TITLE
Fixes for 1D NeuralSurrogate optimisation

### DIFF
--- a/lib/SurrogatesFlux/src/SurrogatesFlux.jl
+++ b/lib/SurrogatesFlux/src/SurrogatesFlux.jl
@@ -91,6 +91,8 @@ function SurrogatesBase.update!(my_n::NeuralSurrogate, x_new, y_new)
         else
             x_new = reduce(hcat, x_new)
         end
+    elseif x_new isa Number
+        x_new = reduce(hcat, [[x_new]])
     end
     y_new = reduce(hcat, y_new)
     opt_state = Flux.setup(my_n.opt, my_n.model)

--- a/lib/SurrogatesFlux/test/runtests.jl
+++ b/lib/SurrogatesFlux/test/runtests.jl
@@ -63,7 +63,19 @@ using SafeTestsets
         update!(surrogate, x_new, y_new)
     end
 
-    @testset "Optimization" begin
+    @testset "1D Optimization" begin
+        lb = 0.0
+        ub = 10.0
+        x = sample(5, lb, ub, SobolSample())
+        objective_function_1D = z -> 2 * z + 3
+        y = objective_function_1D.(x)
+        model = Chain(Dense(1, 1), first)
+        my_neural_1D_neural = NeuralSurrogate(x, y, lb, ub, model = model)
+        surrogate_optimize!(objective_function_1D, SRBF(), lb, ub, my_neural_1D_neural,
+            SobolSample(), maxiters = 15)
+    end
+
+    @testset "ND Optimization" begin
         lb = [1.0, 1.0]
         ub = [6.0, 6.0]
         x = sample(5, lb, ub, SobolSample())


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Added option to SurrogatesFlux to allow x_new::Number in update! with appropriate conversion into a Matrix, matching [this](https://github.com/SciML/Surrogates.jl/blob/a86ebf4569078bc812dd44fe042cde870bec87c9/lib/SurrogatesFlux/src/SurrogatesFlux.jl#L79) form
