### PR TITLE
build: increment patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
 authors = ["SciML"]
-version = "7.0.0"
+version = "7.0.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -28,7 +28,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [extensions]
 SurrogatesAbstractGPsExt = "AbstractGPs"
-SurrogatesFluxExt = ["Flux"]
+SurrogatesFluxExt = "Flux"
 SurrogatesPolyChaosExt = "PolyChaos"
 SurrogatesXGBoostExt = "XGBoost"
 SurrogatesSVMExt = "LIBSVM"


### PR DESCRIPTION
As docs failed in release of 7.0.0, merging, releasing and tagging 7.0.1 should deploy the latest docs to stable.