### PR TITLE
Add JET.jl static analysis tests and fix Kriging type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ ForwardDiff = "0.10.38"
 GaussianMixtures = "0.3.13"
 GLM = "1.9"
 IterativeSolvers = "0.9"
+JET = "0.9, 0.10, 0.11"
 LIBSVM = "0.8"
 LinearAlgebra = "1.10"
 Optimisers = "0.4.4"
@@ -71,6 +72,7 @@ Cubature = "667455a9-e2ce-5579-9412-b964f529a492"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -83,4 +85,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["AbstractGPs", "Aqua", "Cubature", "SafeTestsets", "Flux", "ForwardDiff", "GaussianMixtures", "LIBSVM", "Optimisers", "PolyChaos", "QuadGK", "Random", "StableRNGs", "Test", "Pkg", "XGBoost"]
+test = ["AbstractGPs", "Aqua", "Cubature", "JET", "SafeTestsets", "Flux", "ForwardDiff", "GaussianMixtures", "LIBSVM", "Optimisers", "PolyChaos", "QuadGK", "Random", "StableRNGs", "Test", "Pkg", "XGBoost"]

--- a/src/Kriging.jl
+++ b/src/Kriging.jl
@@ -131,7 +131,8 @@ function _calc_kriging_coeffs(x, y, p::Number, theta::Number)
     # singular, at the cost of slightly relaxing the interpolation condition
     # Derived from "An analytic comparison of regularization methods for Gaussian Processes"
     # by Mohammadi et al (https://arxiv.org/pdf/1602.00853.pdf)
-    λ = eigen(R).values
+    # Use Symmetric wrapper to ensure real eigenvalues for the symmetric correlation matrix
+    λ = eigvals(Symmetric(R))
     λmax = λ[end]
     λmin = λ[1]
 
@@ -140,7 +141,7 @@ function _calc_kriging_coeffs(x, y, p::Number, theta::Number)
     if λdiff ≥ 0
         nugget = λdiff / (κmax - 1)
     else
-        nugget = 0.0
+        nugget = zero(λdiff)
     end
 
     one = ones(eltype(x[1]), n)
@@ -208,7 +209,8 @@ function _calc_kriging_coeffs(x, y, p, theta)
     # singular, at the cost of slightly relaxing the interpolation condition
     # Derived from "An analytic comparison of regularization methods for Gaussian Processes"
     # by Mohammadi et al (https://arxiv.org/pdf/1602.00853.pdf)
-    λ = eigen(R).values
+    # Use Symmetric wrapper to ensure real eigenvalues for the symmetric correlation matrix
+    λ = eigvals(Symmetric(R))
 
     λmax = λ[end]
     λmin = λ[1]
@@ -218,7 +220,7 @@ function _calc_kriging_coeffs(x, y, p, theta)
     if λdiff ≥ 0
         nugget = λdiff / (κmax - 1)
     else
-        nugget = 0.0
+        nugget = zero(λdiff)
     end
 
     one = ones(eltype(x[1]), n)

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,44 @@
+using Surrogates
+using JET
+using Test
+
+@testset "JET static analysis" begin
+    # Test 1D surrogates
+    x1d = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y1d = [1.0, 4.0, 9.0, 16.0, 25.0]
+    lb1d = 0.0
+    ub1d = 6.0
+
+    @testset "LinearSurrogate" begin
+        rep = JET.report_call(LinearSurrogate, (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+
+    @testset "RadialBasis" begin
+        rep = JET.report_call(RadialBasis, (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+
+    @testset "Kriging" begin
+        rep = JET.report_call(Kriging, (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+
+    @testset "InverseDistanceSurrogate" begin
+        rep = JET.report_call(InverseDistanceSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+
+    @testset "SecondOrderPolynomialSurrogate" begin
+        rep = JET.report_call(SecondOrderPolynomialSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+
+    @testset "LobachevskySurrogate" begin
+        rep = JET.report_call(LobachevskySurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64))
+        @test isempty(JET.get_reports(rep))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ using Pkg
     @safetestset "Quality Assurance" begin
         include("qa.jl")
     end
+    @safetestset "JET Static Analysis" begin
+        include("jet.jl")
+    end
     @testset "Extensions" begin
         include("extensions.jl")
     end


### PR DESCRIPTION
## Summary

- **Fix Kriging eigenvalue computation for type stability**: The `eigen(R).values` call could theoretically return complex eigenvalues due to floating point errors, even though R is a symmetric correlation matrix. JET.jl detected this could lead to `isless(::Int, ::ComplexF64)` errors when comparing eigenvalue differences. Fixed by using `eigvals(Symmetric(R))` which guarantees real eigenvalues.

- **Add JET.jl test suite**: Added `test/jet.jl` to test core surrogate constructors for static analysis issues. This catches type instabilities and potential runtime errors at test time.

## Changes

1. **src/Kriging.jl**:
   - Use `eigvals(Symmetric(R))` instead of `eigen(R).values` to ensure real eigenvalues
   - Use `zero(λdiff)` instead of hardcoded `0.0` for better type stability/generic precision support

2. **test/jet.jl**: New test file with JET analysis for:
   - LinearSurrogate
   - RadialBasis
   - Kriging
   - InverseDistanceSurrogate
   - SecondOrderPolynomialSurrogate
   - LobachevskySurrogate

3. **Project.toml**: Added JET as a test dependency

## Test plan

- [x] All existing tests pass (`Pkg.test()` completed successfully - 317 tests)
- [x] JET analysis of Kriging now passes without errors
- [x] Kriging surrogate still produces correct predictions

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)