### PR TITLE
Bump version to 7.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.1.0"
+version = "7.2.0"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
## Version Bump

Bumping version from 7.1.0 to 7.2.0 to prepare for release.

### Changes since last release (v7.1.0)

- **PrecompileTools integration**: Added PrecompileTools workload for faster TTFX (#531)
- **JET.jl static analysis**: Added JET.jl static analysis tests and fixed Kriging type stability (#529)
- **CI modernization**: Migrated from CompatHelper to Dependabot for dependency management (#527)
- **Dependency updates**: Bumped actions/checkout from 4 to 6 (#526)

Total commits: 10

### Registration Commands

After merging, register with:

```
@JuliaRegistrator register
```

cc @ChrisRackauckas