### PR TITLE
Fix JET tests on Julia 1.10 by using target_modules

### DIFF
--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -9,36 +9,43 @@ using Test
     lb1d = 0.0
     ub1d = 6.0
 
+    # Use target_modules to focus only on Surrogates code and avoid
+    # false positives from external dependencies (e.g., LinearAlgebra on Julia 1.10)
+    jet_kwargs = (; target_modules = (Surrogates,))
+
     @testset "LinearSurrogate" begin
-        rep = JET.report_call(LinearSurrogate, (typeof(x1d), typeof(y1d), Float64, Float64))
+        rep = JET.report_call(LinearSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "RadialBasis" begin
-        rep = JET.report_call(RadialBasis, (typeof(x1d), typeof(y1d), Float64, Float64))
+        rep = JET.report_call(RadialBasis,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "Kriging" begin
-        rep = JET.report_call(Kriging, (typeof(x1d), typeof(y1d), Float64, Float64))
+        rep = JET.report_call(Kriging,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "InverseDistanceSurrogate" begin
         rep = JET.report_call(InverseDistanceSurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64))
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "SecondOrderPolynomialSurrogate" begin
         rep = JET.report_call(SecondOrderPolynomialSurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64))
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "LobachevskySurrogate" begin
         rep = JET.report_call(LobachevskySurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64))
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
         @test isempty(JET.get_reports(rep))
     end
 end


### PR DESCRIPTION
## Summary
- Fixed JET static analysis tests that were failing on Julia 1.10 LTS
- Added `target_modules=(Surrogates,)` parameter to focus analysis on package code only

## Problem
CI was broken on master (issue #534) due to JET tests failing on Julia 1.10. The tests were detecting false positives in external dependencies (LinearAlgebra's `hemv!` and a boolean context issue in `gemv!`).

## Solution
Use the `target_modules` parameter in JET.report_call() to focus the static analysis only on the Surrogates module code, avoiding spurious errors from Julia's standard library that don't represent actual issues in the package.

## Test plan
- [x] Verified JET tests now pass on Julia 1.10.10 (LTS)
- [x] Verified full test suite passes on Julia 1.10 (317 tests)
- [x] Verified full test suite passes on Julia 1.12 (317 tests)

Fixes #534

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)