### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,12 +10,16 @@ using Plots
 
 include("pages.jl")
 
-makedocs(sitename = "Surrogates.jl",
+makedocs(
+    sitename = "Surrogates.jl",
     linkcheck = true,
     warnonly = [:missing_docs],
-    format = Documenter.HTML(analytics = "UA-90474609-3",
+    format = Documenter.HTML(
+        analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/Surrogates/stable/"),
-    pages = pages)
+        canonical = "https://docs.sciml.ai/Surrogates/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(repo = "github.com/SciML/Surrogates.jl.git")

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,40 +1,42 @@
-pages = ["index.md"
-         "Tutorials" => [
-             "Basics" => "tutorials.md",
-             "Radials" => "radials.md",
-             "Kriging" => "kriging.md",
-             "Gaussian Process" => "abstractgps.md",
-             "Lobachevsky" => "lobachevsky.md",
-             "Linear" => "LinearSurrogate.md",
-             "InverseDistance" => "InverseDistance.md",
-             "XGBoost" => "xgboost.md",
-             "SecondOrderPolynomial" => "secondorderpoly.md",
-             "NeuralSurrogate" => "neural.md",
-             "Wendland" => "wendland.md",
-             "Polynomial Chaos" => "polychaos.md",
-             "Variable Fidelity" => "variablefidelity.md",
-             "Gradient Enhanced Kriging" => "gek.md",
-             "GEKPLS" => "gekpls.md",
-             "MOE" => "moe.md",
-             "Parallel Optimization" => "parallel.md"
-         ]
-         "User guide" => [
-             "Samples" => "samples.md",
-             "Surrogates" => "surrogate.md",
-             "Optimization" => "optimizations.md"
-         ]
-         "Benchmarks" => [
-             "Sphere function" => "sphere_function.md",
-             "Lp norm" => "lp.md",
-             "Rosenbrock" => "rosenbrock.md",
-             "Tensor product" => "tensor_prod.md",
-             "Cantilever beam" => "cantilever.md",
-             "Water Flow function" => "water_flow.md",
-             "Welded beam function" => "welded_beam.md",
-             "Branin function" => "BraninFunction.md",
-             "Improved Branin function" => "ImprovedBraninFunction.md",
-             "Ackley function" => "ackley.md",
-             "Gramacy & Lee Function" => "gramacylee.md",
-             "Salustowicz Benchmark" => "Salustowicz.md",
-             "Multi objective optimization" => "multi_objective_opt.md"
-         ]]
+pages = [
+    "index.md"
+    "Tutorials" => [
+        "Basics" => "tutorials.md",
+        "Radials" => "radials.md",
+        "Kriging" => "kriging.md",
+        "Gaussian Process" => "abstractgps.md",
+        "Lobachevsky" => "lobachevsky.md",
+        "Linear" => "LinearSurrogate.md",
+        "InverseDistance" => "InverseDistance.md",
+        "XGBoost" => "xgboost.md",
+        "SecondOrderPolynomial" => "secondorderpoly.md",
+        "NeuralSurrogate" => "neural.md",
+        "Wendland" => "wendland.md",
+        "Polynomial Chaos" => "polychaos.md",
+        "Variable Fidelity" => "variablefidelity.md",
+        "Gradient Enhanced Kriging" => "gek.md",
+        "GEKPLS" => "gekpls.md",
+        "MOE" => "moe.md",
+        "Parallel Optimization" => "parallel.md",
+    ]
+    "User guide" => [
+        "Samples" => "samples.md",
+        "Surrogates" => "surrogate.md",
+        "Optimization" => "optimizations.md",
+    ]
+    "Benchmarks" => [
+        "Sphere function" => "sphere_function.md",
+        "Lp norm" => "lp.md",
+        "Rosenbrock" => "rosenbrock.md",
+        "Tensor product" => "tensor_prod.md",
+        "Cantilever beam" => "cantilever.md",
+        "Water Flow function" => "water_flow.md",
+        "Welded beam function" => "welded_beam.md",
+        "Branin function" => "BraninFunction.md",
+        "Improved Branin function" => "ImprovedBraninFunction.md",
+        "Ackley function" => "ackley.md",
+        "Gramacy & Lee Function" => "gramacylee.md",
+        "Salustowicz Benchmark" => "Salustowicz.md",
+        "Multi objective optimization" => "multi_objective_opt.md",
+    ]
+]

--- a/ext/SurrogatesAbstractGPsExt.jl
+++ b/ext/SurrogatesAbstractGPsExt.jl
@@ -5,7 +5,7 @@ using SurrogatesBase, AbstractGPs
 
 # constructor
 function AbstractGPSurrogate(x, y; gp = GP(Matern52Kernel()), Σy = 0.1)
-    AbstractGPSurrogate(x, y, gp, posterior(gp(x, Σy), y), Σy)
+    return AbstractGPSurrogate(x, y, gp, posterior(gp(x, Σy), y), Σy)
 end
 
 # predictor
@@ -21,11 +21,11 @@ function SurrogatesBase.update!(g::AbstractGPSurrogate, new_x, new_y)
     g.x = vcat(g.x, new_x)
     g.y = vcat(g.y, new_y)
     g.gp_posterior = posterior(g.gp(g.x, g.Σy), g.y)
-    nothing
+    return nothing
 end
 
 function SurrogatesBase.finite_posterior(g::AbstractGPSurrogate, xs)
-    g.gp_posterior(xs)
+    return g.gp_posterior(xs)
 end
 
 function Surrogates.std_error_at_point(g::AbstractGPSurrogate, val)

--- a/ext/SurrogatesFluxExt.jl
+++ b/ext/SurrogatesFluxExt.jl
@@ -25,9 +25,11 @@ using Flux
   - `opt`: Optimiser defined using Optimisers.jl
   - `n_epochs`: number of epochs for training
 """
-function NeuralSurrogate(x, y, lb, ub; model = Chain(Dense(length(x[1]), 1)),
-        loss = Flux.mse, opt = Optimisers.Adam(1e-3),
-        n_epochs::Int = 10)
+function NeuralSurrogate(
+        x, y, lb, ub; model = Chain(Dense(length(x[1]), 1)),
+        loss = Flux.mse, opt = Optimisers.Adam(1.0e-3),
+        n_epochs::Int = 10
+    )
     if x isa Tuple
         x = reduce(hcat, x)'
     elseif x isa Vector{<:Tuple}
@@ -93,7 +95,7 @@ function SurrogatesBase.update!(my_n::NeuralSurrogate, x_new, y_new)
     my_n.ps = Flux.trainable(my_n.model)
     my_n.x = hcat(my_n.x, x_new)
     my_n.y = hcat(my_n.y, y_new)
-    nothing
+    return nothing
 end
 
 end # module

--- a/ext/SurrogatesPolyChaosExt.jl
+++ b/ext/SurrogatesPolyChaosExt.jl
@@ -4,49 +4,62 @@ using Surrogates: PolynomialChaosSurrogate
 using SurrogatesBase
 using PolyChaos
 
-function PolynomialChaosSurrogate(x, y, lb::Number, ub::Number;
-        orthopolys::AbstractCanonicalOrthoPoly = GaussOrthoPoly(2))
+function PolynomialChaosSurrogate(
+        x, y, lb::Number, ub::Number;
+        orthopolys::AbstractCanonicalOrthoPoly = GaussOrthoPoly(2)
+    )
     n = length(x)
     poly_degree = orthopolys.deg
     num_of_multi_indexes = 1 + poly_degree
     if n < 2 + 3 * num_of_multi_indexes
-        error("To avoid numerical problems, it's strongly suggested to have at least $(2+3*num_of_multi_indexes) samples")
+        error("To avoid numerical problems, it's strongly suggested to have at least $(2 + 3 * num_of_multi_indexes) samples")
     end
     coeff = _calculatepce_coeff(x, y, num_of_multi_indexes, orthopolys)
     return PolynomialChaosSurrogate(x, y, lb, ub, coeff, orthopolys, num_of_multi_indexes)
 end
 
-function PolynomialChaosSurrogate(x, y, lb, ub;
-        orthopolys = MultiOrthoPoly([GaussOrthoPoly(2) for j in 1:length(lb)], 2))
+function PolynomialChaosSurrogate(
+        x, y, lb, ub;
+        orthopolys = MultiOrthoPoly([GaussOrthoPoly(2) for j in 1:length(lb)], 2)
+    )
     n = length(x)
     d = length(lb)
     poly_degree = orthopolys.deg
     num_of_multi_indexes = binomial(d + poly_degree, poly_degree)
     if n < 2 + 3 * num_of_multi_indexes
-        error("To avoid numerical problems, it's strongly suggested to have at least $(2+3*num_of_multi_indexes) samples")
+        error("To avoid numerical problems, it's strongly suggested to have at least $(2 + 3 * num_of_multi_indexes) samples")
     end
     coeff = _calculatepce_coeff(x, y, num_of_multi_indexes, orthopolys)
     return PolynomialChaosSurrogate(x, y, lb, ub, coeff, orthopolys, num_of_multi_indexes)
 end
 
 function (pc::PolynomialChaosSurrogate)(val::Number)
-    return sum([pc.coeff[i] * PolyChaos.evaluate(val, pc.orthopolys)[i]
-                for i in 1:(pc.num_of_multi_indexes)])
+    return sum(
+        [
+            pc.coeff[i] * PolyChaos.evaluate(val, pc.orthopolys)[i]
+                for i in 1:(pc.num_of_multi_indexes)
+        ]
+    )
 end
 
 function (pcND::PolynomialChaosSurrogate)(val)
     sum = zero(eltype(val))
     for i in 1:(pcND.num_of_multi_indexes)
         sum = sum +
-              pcND.coeff[i] *
-              first(PolyChaos.evaluate(pcND.orthopolys.ind[i, :], collect(val),
-            pcND.orthopolys))
+            pcND.coeff[i] *
+            first(
+            PolyChaos.evaluate(
+                pcND.orthopolys.ind[i, :], collect(val),
+                pcND.orthopolys
+            )
+        )
     end
     return sum
 end
 
 function _calculatepce_coeff(
-        x, y, num_of_multi_indexes, orthopolys::AbstractCanonicalOrthoPoly)
+        x, y, num_of_multi_indexes, orthopolys::AbstractCanonicalOrthoPoly
+    )
     n = length(x)
     A = zeros(eltype(x), n, num_of_multi_indexes)
     for i in 1:n
@@ -72,9 +85,11 @@ end
 function SurrogatesBase.update!(polych::PolynomialChaosSurrogate, x_new, y_new)
     polych.x = vcat(polych.x, x_new)
     polych.y = vcat(polych.y, y_new)
-    polych.coeff = _calculatepce_coeff(polych.x, polych.y, polych.num_of_multi_indexes,
-        polych.orthopolys)
-    nothing
+    polych.coeff = _calculatepce_coeff(
+        polych.x, polych.y, polych.num_of_multi_indexes,
+        polych.orthopolys
+    )
+    return nothing
 end
 
 end # module

--- a/ext/SurrogatesSVMExt.jl
+++ b/ext/SurrogatesSVMExt.jl
@@ -28,7 +28,7 @@ function SVMSurrogate(x, y, lb, ub)
         end
     end
     model = LIBSVM.fit!(SVC(), X, y)
-    SVMSurrogate(x, y, model, lb, ub)
+    return SVMSurrogate(x, y, model, lb, ub)
 end
 
 function (svmsurr::SVMSurrogate)(val::Number)
@@ -52,12 +52,14 @@ end
 function SurrogatesBase.update!(svmsurr::SVMSurrogate, x_new, y_new)
     svmsurr.x = vcat(svmsurr.x, x_new)
     svmsurr.y = vcat(svmsurr.y, y_new)
-    if length(svmsurr.lb) == 1
+    return if length(svmsurr.lb) == 1
         svmsurr.model = LIBSVM.fit!(
-            SVC(), reshape(svmsurr.x, length(svmsurr.x), 1), svmsurr.y)
+            SVC(), reshape(svmsurr.x, length(svmsurr.x), 1), svmsurr.y
+        )
     else
         svmsurr.model = LIBSVM.fit!(
-            SVC(), transpose(reduce(hcat, collect.(svmsurr.x))), svmsurr.y)
+            SVC(), transpose(reduce(hcat, collect.(svmsurr.x))), svmsurr.y
+        )
     end
 end
 

--- a/ext/SurrogatesXGBoostExt.jl
+++ b/ext/SurrogatesXGBoostExt.jl
@@ -32,7 +32,7 @@ function XGBoostSurrogate(x, y, lb, ub; num_round::Int = 1)
         end
     end
     bst = xgboost((X, y); num_round)
-    XGBoostSurrogate(X, y, bst, lb, ub, num_round)
+    return XGBoostSurrogate(X, y, bst, lb, ub, num_round)
 end
 
 function (rndfor::XGBoostSurrogate)(val::Number)
@@ -58,13 +58,16 @@ function SurrogatesBase.update!(rndfor::XGBoostSurrogate, x_new, y_new)
     rndfor.x = vcat(rndfor.x, x_new)
     rndfor.y = vcat(rndfor.y, y_new)
     if length(rndfor.lb) == 1
-        rndfor.bst = xgboost((rndfor.x, rndfor.y);
-            num_round = rndfor.num_round)
+        rndfor.bst = xgboost(
+            (rndfor.x, rndfor.y);
+            num_round = rndfor.num_round
+        )
     else
         rndfor.bst = xgboost(
-            (rndfor.x, rndfor.y); num_round = rndfor.num_round)
+            (rndfor.x, rndfor.y); num_round = rndfor.num_round
+        )
     end
-    nothing
+    return nothing
 end
 
 end # module

--- a/src/GEKPLS.jl
+++ b/src/GEKPLS.jl
@@ -71,25 +71,32 @@ function GEKPLS(x_vec, y_vec, grads_vec, n_comp, delta_x, lb, ub, extra_points, 
     end
 
     pls_mean, X_after_PLS,
-    y_after_PLS = _ge_compute_pls(X, y, n_comp, grads, delta_x,
-        xlimits, extra_points)
+        y_after_PLS = _ge_compute_pls(
+        X, y, n_comp, grads, delta_x,
+        xlimits, extra_points
+    )
     X_after_std, y_after_std, X_offset, y_mean,
-    X_scale, y_std = standardization(
+        X_scale, y_std = standardization(
         X_after_PLS,
-        y_after_PLS)
+        y_after_PLS
+    )
     D, ij = cross_distances(X_after_std)
     pls_mean_reshaped = reshape(pls_mean, (size(X, 2), n_comp))
     d = componentwise_distance_PLS(D, "squar_exp", n_comp, pls_mean_reshaped)
     nt, nd = size(X_after_PLS)
     beta, gamma,
-    reduced_likelihood_function_value = _reduced_likelihood_function(theta,
+        reduced_likelihood_function_value = _reduced_likelihood_function(
+        theta,
         "squar_exp",
         d, nt, ij,
-        y_after_std)
-    return GEKPLS(x_vec, y_vec, X, y, grads, xlimits, delta_x, extra_points, n_comp, beta,
+        y_after_std
+    )
+    return GEKPLS(
+        x_vec, y_vec, X, y, grads, xlimits, delta_x, extra_points, n_comp, beta,
         gamma, theta,
         reduced_likelihood_function_value,
-        X_offset, X_scale, X_after_std, pls_mean_reshaped, y_mean, y_std)
+        X_offset, X_scale, X_after_std, pls_mean_reshaped, y_mean, y_std
+    )
 end
 
 """
@@ -155,26 +162,30 @@ function SurrogatesBase.update!(g::GEKPLS, x_tup, y_val, grad_tup)
     g.y_matrix = vcat(g.y_matrix, y_val)
     g.grads = vcat(g.grads, new_grads)
     pls_mean, X_after_PLS,
-    y_after_PLS = _ge_compute_pls(g.x_matrix, g.y_matrix,
+        y_after_PLS = _ge_compute_pls(
+        g.x_matrix, g.y_matrix,
         g.num_components,
         g.grads, g.delta, g.xl,
-        g.extra_points)
+        g.extra_points
+    )
     g.X_after_std, y_after_std, g.X_offset, g.y_mean,
-    g.X_scale, g.y_std = standardization(
+        g.X_scale, g.y_std = standardization(
         X_after_PLS,
-        y_after_PLS)
+        y_after_PLS
+    )
     D, ij = cross_distances(g.X_after_std)
     g.pls_mean = reshape(pls_mean, (size(g.x_matrix, 2), g.num_components))
     d = componentwise_distance_PLS(D, "squar_exp", g.num_components, g.pls_mean)
     nt, nd = size(X_after_PLS)
-    g.beta, g.gamma,
-    g.reduced_likelihood_function_value = _reduced_likelihood_function(
+    return g.beta, g.gamma,
+        g.reduced_likelihood_function_value = _reduced_likelihood_function(
         g.theta,
         "squar_exp",
         d,
         nt,
         ij,
-        y_after_std)
+        y_after_std
+    )
 end
 
 """
@@ -214,19 +225,23 @@ function _ge_compute_pls(X, y, n_comp, grads, delta_x, xlimits, extra_points)
         if dim >= 3
             bb_vals = circshift(boxbehnken(dim, 1), 1)
         elseif dim == 2
-            bb_vals = [0.0 0.0; #center
-                       1.0 0.0; #right
-                       0.0 1.0; #up
-                       -1.0 0.0; #left
-                       0.0 -1.0; #down
-                       1.0 1.0; #right up
-                       -1.0 1.0; #left up
-                       -1.0 -1.0; #left down
-                       1.0 -1.0]
+            bb_vals = [
+                0.0 0.0; #center
+                1.0 0.0; #right
+                0.0 1.0; #up
+                -1.0 0.0; #left
+                0.0 -1.0; #down
+                1.0 1.0; #right up
+                -1.0 1.0; #left up
+                -1.0 -1.0; #left down
+                1.0 -1.0
+            ]
         else # dim == 1
-            bb_vals = [0.0; #center
-                       1.0; #right
-                       -1.0] #left
+            bb_vals = [
+                0.0; #center
+                1.0; #right
+                -1.0
+            ] #left
         end
         _X = zeros((size(bb_vals)[1], dim))
         _y = zeros((size(bb_vals)[1], 1))
@@ -290,7 +305,7 @@ end
 #
 
 function boxbehnken(matrix_size::Int)
-    boxbehnken(matrix_size, matrix_size)
+    return boxbehnken(matrix_size, matrix_size)
 end
 
 function boxbehnken(matrix_size::Int, center::Int)
@@ -306,10 +321,14 @@ function boxbehnken(matrix_size::Int, center::Int)
     for i in 1:(matrix_size - 1)
         for j in (i + 1):matrix_size
             l = l + 1
-            A[(max(0, (l - 1) * size(A_fact)[1]) + 1):(l * size(A_fact)[1]), i] = A_fact[:,
-            1]
-            A[(max(0, (l - 1) * size(A_fact)[1]) + 1):(l * size(A_fact)[1]), j] = A_fact[:,
-            2]
+            A[(max(0, (l - 1) * size(A_fact)[1]) + 1):(l * size(A_fact)[1]), i] = A_fact[
+                :,
+                1,
+            ]
+            A[(max(0, (l - 1) * size(A_fact)[1]) + 1):(l * size(A_fact)[1]), j] = A_fact[
+                :,
+                2,
+            ]
         end
     end
 
@@ -320,19 +339,19 @@ function boxbehnken(matrix_size::Int, center::Int)
         end
     end
 
-    A = transpose(hcat(transpose(A), transpose(zeros(center, matrix_size))))
+    return A = transpose(hcat(transpose(A), transpose(zeros(center, matrix_size))))
 end
 
 function explicit_fullfactorial(factors::Tuple)
-    explicit_fullfactorial(fullfactorial(factors))
+    return explicit_fullfactorial(fullfactorial(factors))
 end
 
 function explicit_fullfactorial(iterator::Base.Iterators.ProductIterator)
-    hcat(vcat.(collect(iterator)...)...)
+    return hcat(vcat.(collect(iterator)...)...)
 end
 
 function fullfactorial(factors::Tuple)
-    Base.Iterators.product(factors...)
+    return Base.Iterators.product(factors...)
 end
 
 ######end of bb design######
@@ -590,7 +609,7 @@ function _svd_flip_1d(u, v)
     biggest_abs_val_idx = findmax(abs.(vec(u)))[2]
     sign_ = sign(u[biggest_abs_val_idx])
     u .*= sign_
-    v .*= sign_
+    return v .*= sign_
 end
 
 function _get_first_singular_vectors_power_method(X, Y)

--- a/src/InverseDistanceSurrogate.jl
+++ b/src/InverseDistanceSurrogate.jl
@@ -26,10 +26,14 @@ function (inverSurr::InverseDistanceSurrogate)(val)
         return inverSurr.y[findfirst(x -> x == val, inverSurr.x)]
     else
         if length(inverSurr.lb) == 1
-            num = sum(inverSurr.y[i] * (norm(val .- inverSurr.x[i]))^(-inverSurr.p)
-            for i in 1:length(inverSurr.x))
-            den = sum(norm(val .- inverSurr.x[i])^(-inverSurr.p)
-            for i in 1:length(inverSurr.x))
+            num = sum(
+                inverSurr.y[i] * (norm(val .- inverSurr.x[i]))^(-inverSurr.p)
+                    for i in 1:length(inverSurr.x)
+            )
+            den = sum(
+                norm(val .- inverSurr.x[i])^(-inverSurr.p)
+                    for i in 1:length(inverSurr.x)
+            )
             return num / den
         else
             βᵢ = [norm(val .- inverSurr.x[i])^(-inverSurr.p) for i in 1:length(inverSurr.x)]
@@ -50,5 +54,5 @@ function SurrogatesBase.update!(inverSurr::InverseDistanceSurrogate, x_new, y_ne
         push!(inverSurr.x, x_new)
         push!(inverSurr.y, y_new)
     end
-    nothing
+    return nothing
 end

--- a/src/LinearSurrogate.jl
+++ b/src/LinearSurrogate.jl
@@ -8,7 +8,7 @@ end
 
 function LinearSurrogate(x, y, lb::Number, ub::Number)
     ols = lm(reshape(x, length(x), 1), y)
-    LinearSurrogate(x, y, coef(ols), lb, ub)
+    return LinearSurrogate(x, y, coef(ols), lb, ub)
 end
 
 function SurrogatesBase.update!(my_linear::LinearSurrogate, new_x, new_y)
@@ -45,12 +45,12 @@ function SurrogatesBase.update!(my_linear::LinearSurrogate, new_x, new_y)
         md = lm(X, my_linear.y)
         my_linear.coeff = coef(md)
     end
-    nothing
+    return nothing
 end
 
 function (lin::LinearSurrogate)(val::Number)
     _check_dimension(lin, val)
-    return lin.coeff[1]*val
+    return lin.coeff[1] * val
 end
 
 function (lin::LinearSurrogate)(val)

--- a/src/Lobachevsky.jl
+++ b/src/Lobachevsky.jl
@@ -1,5 +1,5 @@
 mutable struct LobachevskySurrogate{X, Y, A, N, L, U, C, S} <:
-               AbstractDeterministicSurrogate
+    AbstractDeterministicSurrogate
     x::X
     y::Y
     alpha::A
@@ -46,7 +46,8 @@ Lobachevsky interpolation, suggested parameters: 0 <= alpha <= 4, n must be even
 """
 function LobachevskySurrogate(
         x, y, lb::Number, ub::Number; alpha::Number = 1.0, n::Int = 4,
-        sparse = false)
+        sparse = false
+    )
     if alpha > 4 || alpha < 0
         error("Alpha must be between 0 and 4")
     end
@@ -54,15 +55,17 @@ function LobachevskySurrogate(
         error("Parameter n must be even")
     end
     coeff = _calc_loba_coeff1D(x, y, alpha, n, sparse)
-    LobachevskySurrogate(x, y, alpha, n, lb, ub, coeff, sparse)
+    return LobachevskySurrogate(x, y, alpha, n, lb, ub, coeff, sparse)
 end
 
 function (loba::LobachevskySurrogate)(val::Number)
     # Check to make sure dimensions of input matches expected dimension of surrogate
     _check_dimension(loba, val)
 
-    return sum(loba.coeff[j] * phi_nj1D(val, loba.x[j], loba.alpha, loba.n)
-    for j in 1:length(loba.x))
+    return sum(
+        loba.coeff[j] * phi_nj1D(val, loba.x[j], loba.alpha, loba.n)
+            for j in 1:length(loba.x)
+    )
 end
 
 function phi_njND(point, x, alpha, n)
@@ -89,20 +92,24 @@ LobachevskySurrogate(x,y,alpha,n::Int,lb,ub,sparse = false)
 
 Build the Lobachevsky surrogate with parameters alpha and n.
 """
-function LobachevskySurrogate(x, y, lb, ub; alpha = collect(one.(x[1])), n::Int = 4,
-        sparse = false)
+function LobachevskySurrogate(
+        x, y, lb, ub; alpha = collect(one.(x[1])), n::Int = 4,
+        sparse = false
+    )
     if n % 2 != 0
         error("Parameter n must be even")
     end
     coeff = _calc_loba_coeffND(x, y, alpha, n, sparse)
-    LobachevskySurrogate(x, y, alpha, n, lb, ub, coeff, sparse)
+    return LobachevskySurrogate(x, y, alpha, n, lb, ub, coeff, sparse)
 end
 
 function (loba::LobachevskySurrogate)(val)
     # Check to make sure dimensions of input matches expected dimension of surrogate
     _check_dimension(loba, val)
-    return sum(loba.coeff[j] * phi_njND(val, loba.x[j], loba.alpha, loba.n)
-    for j in 1:length(loba.x))
+    return sum(
+        loba.coeff[j] * phi_njND(val, loba.x[j], loba.alpha, loba.n)
+            for j in 1:length(loba.x)
+    )
 end
 
 function SurrogatesBase.update!(loba::LobachevskySurrogate, x_new, y_new)
@@ -117,7 +124,7 @@ function SurrogatesBase.update!(loba::LobachevskySurrogate, x_new, y_new)
         loba.y = vcat(loba.y, y_new)
         loba.coeff = _calc_loba_coeffND(loba.x, loba.y, loba.alpha, loba.n, loba.sparse)
     end
-    nothing
+    return nothing
 end
 
 #Lobachevsky integrals
@@ -129,7 +136,7 @@ function _phi_int(point, n)
             res = res + (-1)^k * binomial(n, k) * c^n
         end
     end
-    res *= 1 / (2^n * factorial(n))
+    return res *= 1 / (2^n * factorial(n))
 end
 
 function lobachevsky_integral(loba::LobachevskySurrogate, lb::Number, ub::Number)
@@ -197,6 +204,8 @@ function lobachevsky_integrate_dimension(loba::LobachevskySurrogate, lb, ub, dim
     new_lb = deleteat!(lb, dim)
     new_ub = deleteat!(ub, dim)
     new_loba = deleteat!(loba.alpha, dim)
-    return LobachevskySurrogate(new_x, loba.y, loba.alpha, loba.n, new_lb, new_ub,
-        new_coeff, loba.sparse)
+    return LobachevskySurrogate(
+        new_x, loba.y, loba.alpha, loba.n, new_lb, new_ub,
+        new_coeff, loba.sparse
+    )
 end

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -35,7 +35,8 @@ end
 
 function merit_function(
         point, w, surr::AbstractSurrogate, s_max, s_min, d_max, d_min,
-        box_size)
+        box_size
+    )
     if length(point) == 1
         D_x = box_size + 1
         for i in 1:length(surr.x)
@@ -45,7 +46,7 @@ function merit_function(
             end
         end
         return w * (surr(point) - s_min) / (s_max - s_min) +
-               (1 - w) * ((d_max - D_x) / (d_max - d_min))
+            (1 - w) * ((d_max - D_x) / (d_max - d_min))
     else
         D_x = norm(box_size) + 1
         for i in 1:length(surr.x)
@@ -55,7 +56,7 @@ function merit_function(
             end
         end
         return w * (surr(point) - s_min) / (s_max - s_min) +
-               (1 - w) * ((d_max - D_x) / (d_max - d_min))
+            (1 - w) * ((d_max - D_x) / (d_max - d_min))
     end
 end
 
@@ -89,7 +90,8 @@ When w is close to zero, we do pure exploration, while w close to 1 corresponds 
 function surrogate_optimize!(
         obj::Function, ::SRBF, lb, ub, surr::AbstractSurrogate,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100, needs_gradient = false)
+        num_new_samples = 100, needs_gradient = false
+    )
     scale = 0.2
     success = 0
     failure = 0
@@ -99,7 +101,7 @@ function surrogate_optimize!(
     box_size = lb - ub
     success = 0
     failures = 0
-    dtol = 1e-3 * norm(ub - lb)
+    dtol = 1.0e-3 * norm(ub - lb)
     d = length(surr.x)
     num_of_iterations = 0
     for w in Iterators.cycle(w_range)
@@ -142,9 +144,11 @@ function surrogate_optimize!(
 
             evaluation_of_merit_function = zeros(float(eltype(surr.x[1])), num_new_samples)
             @inbounds for r in 1:num_new_samples
-                evaluation_of_merit_function[r] = merit_function(new_sample[r], w, surr,
+                evaluation_of_merit_function[r] = merit_function(
+                    new_sample[r], w, surr,
                     s_max, s_min, d_max, d_min,
-                    box_size)
+                    box_size
+                )
             end
             new_addition = false
             adaptive_point_x = Tuple{}
@@ -222,7 +226,7 @@ function surrogate_optimize!(
             if failure == 5
                 scale = scale / 2
                 #check bounds and go on only if > 1e-5*interval
-                if scale < 1e-5
+                if scale < 1.0e-5
                     println("Exiting, too narrow")
                     index = argmin(surr.y)
                     return (surr.x[index], surr.y[index])
@@ -232,15 +236,18 @@ function surrogate_optimize!(
             end
         end
     end
+    return
 end
 
 """
 SRBF 1D:
 surrogate_optimize!(obj::Function,::SRBF,lb::Number,ub::Number,surr::AbstractSurrogate,sample_type::SamplingAlgorithm;maxiters=100,num_new_samples=100)
 """
-function surrogate_optimize!(obj::Function, ::SRBF, lb::Number, ub::Number,
+function surrogate_optimize!(
+        obj::Function, ::SRBF, lb::Number, ub::Number,
         surr::AbstractSurrogate, sample_type::SamplingAlgorithm;
-        maxiters = 100, num_new_samples = 100)
+        maxiters = 100, num_new_samples = 100
+    )
     #Suggested by:
     #https://www.mathworks.com/help/gads/surrogate-optimization-algorithm.html
     scale = 0.2
@@ -250,7 +257,7 @@ function surrogate_optimize!(obj::Function, ::SRBF, lb::Number, ub::Number,
     box_size = lb - ub
     success = 0
     failures = 0
-    dtol = 1e-3 * norm(ub - lb)
+    dtol = 1.0e-3 * norm(ub - lb)
     num_of_iterations = 0
     for w in Iterators.cycle(w_range)
         num_of_iterations += 1
@@ -296,9 +303,12 @@ function surrogate_optimize!(obj::Function, ::SRBF, lb::Number, ub::Number,
             end
             #3) Evaluate merit function at the sampled points
             evaluation_of_merit_function = map(
-                x -> merit_function(x, w, surr, s_max,
-                    s_min, d_max, d_min, box_size),
-                new_sample)
+                x -> merit_function(
+                    x, w, surr, s_max,
+                    s_min, d_max, d_min, box_size
+                ),
+                new_sample
+            )
 
             new_addition = false
             adaptive_point_x = zero(eltype(new_sample[1]))
@@ -367,7 +377,7 @@ function surrogate_optimize!(obj::Function, ::SRBF, lb::Number, ub::Number,
             if failure == 5
                 scale = scale / 2
                 #check bounds and go on only if > 1e-5*interval
-                if scale < 1e-5
+                if scale < 1.0e-5
                     println("Exiting, too narrow")
                     index = argmin(surr.y)
                     return (surr.x[index], surr.y[index])
@@ -377,13 +387,15 @@ function surrogate_optimize!(obj::Function, ::SRBF, lb::Number, ub::Number,
             end
         end
     end
+    return
 end
 
 # Ask SRBF ND
 function potential_optimal_points(
         ::SRBF, strategy, lb, ub, surr::AbstractSurrogate,
         sample_type::SamplingAlgorithm, n_parallel;
-        num_new_samples = 500)
+        num_new_samples = 500
+    )
     scale = 0.2
     w_range = [0.3, 0.5, 0.7, 0.95]
     w_cycle = Iterators.cycle(w_range)
@@ -392,7 +404,7 @@ function potential_optimal_points(
 
     #Vector containing size in each direction
     box_size = lb - ub
-    dtol = 1e-3 * norm(ub - lb)
+    dtol = 1.0e-3 * norm(ub - lb)
     d = length(surr.x)
     incumbent_x = surr.x[argmin(surr.y)]
 
@@ -445,9 +457,11 @@ function potential_optimal_points(
         #find minimum
 
         @inbounds for r in eachindex(evaluation_of_merit_function)
-            evaluation_of_merit_function[r] = merit_function(new_sample[r], w, tmp_surr,
+            evaluation_of_merit_function[r] = merit_function(
+                new_sample[r], w, tmp_surr,
                 s_max, s_min, d_max, d_min,
-                box_size)
+                box_size
+            )
         end
 
         min_index = argmin(evaluation_of_merit_function)
@@ -487,10 +501,12 @@ function potential_optimal_points(
 end
 
 # Ask SRBF 1D
-function potential_optimal_points(::SRBF, strategy, lb::Number, ub::Number,
+function potential_optimal_points(
+        ::SRBF, strategy, lb::Number, ub::Number,
         surr::AbstractSurrogate,
         sample_type::SamplingAlgorithm, n_parallel;
-        num_new_samples = 500)
+        num_new_samples = 500
+    )
     scale = 0.2
     success = 0
     w_range = [0.3, 0.5, 0.7, 0.95]
@@ -501,7 +517,7 @@ function potential_optimal_points(::SRBF, strategy, lb::Number, ub::Number,
     box_size = lb - ub
     success = 0
     failures = 0
-    dtol = 1e-3 * norm(ub - lb)
+    dtol = 1.0e-3 * norm(ub - lb)
     num_of_iterations = 0
 
     #1) Sample near incumbent (the 2 fraction is arbitrary here)
@@ -551,8 +567,10 @@ function potential_optimal_points(::SRBF, strategy, lb::Number, ub::Number,
     while new_addition < n_parallel
 
         #3) Evaluate merit function at the sampled points in parallel
-        evaluation_of_merit_function = merit_function.(new_sample, w, tmp_surr, s_max,
-            s_min, d_max, d_min, box_size)
+        evaluation_of_merit_function = merit_function.(
+            new_sample, w, tmp_surr, s_max,
+            s_min, d_max, d_min, box_size
+        )
 
         #find minimum
         min_index = argmin(evaluation_of_merit_function)
@@ -568,8 +586,10 @@ function potential_optimal_points(::SRBF, strategy, lb::Number, ub::Number,
             deleteat!(new_sample, min_index)
             if length(new_sample) == 0
                 println("Out of sampling points")
-                return (proposed_points_x[1:new_addition],
-                    merit_of_proposed_points[1:new_addition])
+                return (
+                    proposed_points_x[1:new_addition],
+                    merit_of_proposed_points[1:new_addition],
+                )
             end
         else
             new_addition += 1
@@ -594,16 +614,18 @@ Under a Gaussian process (GP) prior, the goal is to minimize:
 ``LCB(x) := E[x] - k * \\sqrt{(V[x])}``
 default value ``k = 2``.
 """
-function surrogate_optimize!(obj::Function, ::LCBS, lb::Number, ub::Number, krig,
+function surrogate_optimize!(
+        obj::Function, ::LCBS, lb::Number, ub::Number, krig,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100, k = 2.0)
-    dtol = 1e-3 * norm(ub - lb)
+        num_new_samples = 100, k = 2.0
+    )
+    dtol = 1.0e-3 * norm(ub - lb)
     for i in 1:maxiters
         new_sample = sample(num_new_samples, lb, ub, sample_type)
         evaluations = zeros(eltype(krig.x[1]), num_new_samples)
         for j in 1:num_new_samples
             evaluations[j] = krig(new_sample[j]) +
-                             k * std_error_at_point(krig, new_sample[j])
+                k * std_error_at_point(krig, new_sample[j])
         end
 
         new_addition = false
@@ -634,7 +656,7 @@ function surrogate_optimize!(obj::Function, ::LCBS, lb::Number, ub::Number, krig
                 min_add_y = new_min_y
             end
         end
-        if min_add_y < 1e-6 * (maximum(krig.y) - minimum(krig.y))
+        if min_add_y < 1.0e-6 * (maximum(krig.y) - minimum(krig.y))
             return
         else
             if (abs(min_add_y) == Inf || min_add_y == NaN)
@@ -644,6 +666,7 @@ function surrogate_optimize!(obj::Function, ::LCBS, lb::Number, ub::Number, krig
             end
         end
     end
+    return
 end
 
 """
@@ -655,17 +678,19 @@ Under a Gaussian process (GP) prior, the goal is to minimize:
 
 default value ``k = 2``.
 """
-function surrogate_optimize!(obj::Function, ::LCBS, lb, ub, krig,
+function surrogate_optimize!(
+        obj::Function, ::LCBS, lb, ub, krig,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100, k = 2.0)
-    dtol = 1e-3 * norm(ub - lb)
+        num_new_samples = 100, k = 2.0
+    )
+    dtol = 1.0e-3 * norm(ub - lb)
     for i in 1:maxiters
         d = length(krig.x)
         new_sample = sample(num_new_samples, lb, ub, sample_type)
         evaluations = zeros(eltype(krig.x[1]), num_new_samples)
         for j in 1:num_new_samples
             evaluations[j] = krig(new_sample[j]) +
-                             k * std_error_at_point(krig, new_sample[j])
+                k * std_error_at_point(krig, new_sample[j])
         end
 
         new_addition = false
@@ -698,7 +723,7 @@ function surrogate_optimize!(obj::Function, ::LCBS, lb, ub, krig,
                 min_add_y = new_min_y
             end
         end
-        if min_add_y < 1e-6 * (maximum(krig.y) - minimum(krig.y))
+        if min_add_y < 1.0e-6 * (maximum(krig.y) - minimum(krig.y))
             index = argmin(krig.y)
             return (krig.x[index], krig.y[index])
         else
@@ -710,15 +735,18 @@ function surrogate_optimize!(obj::Function, ::LCBS, lb, ub, krig,
             end
         end
     end
+    return
 end
 
 """
 Expected improvement method 1D
 """
-function surrogate_optimize!(obj::Function, ::EI, lb::Number, ub::Number, krig,
+function surrogate_optimize!(
+        obj::Function, ::EI, lb::Number, ub::Number, krig,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100)
-    dtol = 1e-3 * norm(ub - lb)
+        num_new_samples = 100
+    )
+    dtol = 1.0e-3 * norm(ub - lb)
     eps = 0.01
     for i in 1:maxiters
         # Sample lots of points from the design space -- we will evaluate the EI function at these points
@@ -737,14 +765,14 @@ function surrogate_optimize!(obj::Function, ::EI, lb::Number, ub::Number, krig,
             for j in 1:length(new_sample)
                 std = std_error_at_point(krig, new_sample[j])
                 u = krig(new_sample[j])
-                if abs(std) > 1e-6
+                if abs(std) > 1.0e-6
                     z = (f_min - u - eps) / std
                 else
                     z = 0
                 end
                 # Evaluate EI at point new_sample[j]
                 evaluations[j] = (f_min - u - eps) * cdf(Normal(), z) +
-                                 std * pdf(Normal(), z)
+                    std * pdf(Normal(), z)
             end
             # find the sample which maximizes the EI function
             index_max = argmax(evaluations)
@@ -770,7 +798,7 @@ function surrogate_optimize!(obj::Function, ::EI, lb::Number, ub::Number, krig,
         end
         # if the EI is less than some tolerance times the difference between the maximum and minimum points
         # in the surrogate, then we terminate the optimizer.
-        if new_EI_max < 1e-6 * norm(maximum(krig.y) - minimum(krig.y))
+        if new_EI_max < 1.0e-6 * norm(maximum(krig.y) - minimum(krig.y))
             index = argmin(krig.y)
             println("Termination tolerance reached.")
             return (krig.x[index], krig.y[index])
@@ -778,17 +806,19 @@ function surrogate_optimize!(obj::Function, ::EI, lb::Number, ub::Number, krig,
         # Otherwise, evaluate the true objective function at the new point and repeat.
         update!(krig, new_x_max, obj(new_x_max))
     end
-    println("Completed maximum number of iterations")
+    return println("Completed maximum number of iterations")
 end
 
 # Ask EI 1D & ND
-function potential_optimal_points(::EI, strategy, lb, ub, krig,
+function potential_optimal_points(
+        ::EI, strategy, lb, ub, krig,
         sample_type::SamplingAlgorithm, n_parallel::Number;
-        num_new_samples = 100)
+        num_new_samples = 100
+    )
     lb = krig.lb
     ub = krig.ub
 
-    dtol = 1e-3 * norm(ub - lb)
+    dtol = 1.0e-3 * norm(ub - lb)
     eps = 0.01
 
     tmp_krig = deepcopy(krig) # Temporary copy of the kriging model to store virtual points
@@ -811,14 +841,14 @@ function potential_optimal_points(::EI, strategy, lb, ub, krig,
             for j in eachindex(new_sample)
                 std = std_error_at_point(tmp_krig, new_sample[j])
                 u = tmp_krig(new_sample[j])
-                if abs(std) > 1e-6
+                if abs(std) > 1.0e-6
                     z = (f_min - u - eps) / std
                 else
                     z = 0
                 end
                 # Evaluate EI at point new_sample[j]
                 evaluations[j] = (f_min - u - eps) * cdf(Normal(), z) +
-                                 std * pdf(Normal(), z)
+                    std * pdf(Normal(), z)
             end
             # find the sample which maximizes the EI function
             index_max = argmax(evaluations)
@@ -856,10 +886,12 @@ maximize expected improvement:
 
 ``EI(x) := E[max(f_{best}-f(x),0)``
 """
-function surrogate_optimize!(obj::Function, ::EI, lb, ub, krig,
+function surrogate_optimize!(
+        obj::Function, ::EI, lb, ub, krig,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100)
-    dtol = 1e-3 * norm(ub - lb)
+        num_new_samples = 100
+    )
+    dtol = 1.0e-3 * norm(ub - lb)
     eps = 0.01
     for i in 1:maxiters
         d = length(krig.x)
@@ -880,14 +912,14 @@ function surrogate_optimize!(obj::Function, ::EI, lb, ub, krig,
             for j in 1:length(new_sample)
                 std = std_error_at_point(krig, new_sample[j])
                 u = krig(new_sample[j])
-                if abs(std) > 1e-6
+                if abs(std) > 1.0e-6
                     z = (f_min - u - eps) / std
                 else
                     z = 0
                 end
                 # Evaluate EI at point new_sample[j]
                 evaluations[j] = (f_min - u - eps) * cdf(Normal(), z) +
-                                 std * pdf(Normal(), z)
+                    std * pdf(Normal(), z)
             end
             # find the sample which maximizes the EI function
             index_max = argmax(evaluations)
@@ -915,7 +947,7 @@ function surrogate_optimize!(obj::Function, ::EI, lb, ub, krig,
         end
         # if the EI is less than some tolerance times the difference between the maximum and minimum points
         # in the surrogate, then we terminate the optimizer.
-        if new_EI_max < 1e-6 * norm(maximum(krig.y) - minimum(krig.y))
+        if new_EI_max < 1.0e-6 * norm(maximum(krig.y) - minimum(krig.y))
             index = argmin(krig.y)
             println("Termination tolerance reached.")
             return (krig.x[index], krig.y[index])
@@ -923,7 +955,7 @@ function surrogate_optimize!(obj::Function, ::EI, lb, ub, krig,
         # Otherwise, evaluate the true objective function at the new point and repeat.
         update!(krig, Tuple(new_x_max), obj(new_x_max))
     end
-    println("Completed maximum number of iterations.")
+    return println("Completed maximum number of iterations.")
 end
 
 function adjust_step_size(sigma_n, sigma_min, C_success, t_success, C_fail, t_fail)
@@ -940,7 +972,8 @@ end
 
 function select_evaluation_point_1D(
         new_points1, surr1::AbstractSurrogate, numb_iters,
-        maxiters)
+        maxiters
+    )
     v = [0.3, 0.5, 0.8, 0.95]
     k = 4
     n = length(surr1.x)
@@ -961,7 +994,7 @@ function select_evaluation_point_1D(
     s_min = minimum(evaluations1)
     V_nR = zeros(eltype(surr1.y[1]), l)
     for i in 1:l
-        if abs(s_max - s_min) <= 10e-6
+        if abs(s_max - s_min) <= 10.0e-6
             V_nR[i] = 1.0
         else
             V_nR[i] = (evaluations1[i] - s_min) / (s_max - s_min)
@@ -981,7 +1014,7 @@ function select_evaluation_point_1D(
     delta_n_max = maximum(delta_n_x)
     delta_n_min = minimum(delta_n_x)
     for i in 1:l
-        if abs(delta_n_max - delta_n_min) <= 10e-6
+        if abs(delta_n_max - delta_n_min) <= 10.0e-6
             V_nD[i] = 1.0
         else
             V_nD[i] = (delta_n_max - delta_n_x[i]) / (delta_n_max - delta_n_min)
@@ -999,9 +1032,11 @@ surrogate_optimize!(obj::Function,::DYCORS,lb::Number,ub::Number,surr1::Abstract
 DYCORS optimization method in 1D, following closely: Combining radial basis function
 surrogates and dynamic coordinate search in high-dimensional expensive black-box optimization".
 """
-function surrogate_optimize!(obj::Function, ::DYCORS, lb::Number, ub::Number,
+function surrogate_optimize!(
+        obj::Function, ::DYCORS, lb::Number, ub::Number,
         surr1::AbstractSurrogate, sample_type::SamplingAlgorithm;
-        maxiters = 100, num_new_samples = 100)
+        maxiters = 100, num_new_samples = 100
+    )
     x_best = argmin(surr1.y)
     y_best = minimum(surr1.y)
     sigma_n = 0.2 * norm(ub - lb)
@@ -1022,15 +1057,19 @@ function surrogate_optimize!(obj::Function, ::DYCORS, lb::Number, ub::Number,
             while new_points[i] < lb || new_points[i] > ub
                 if new_points[i] > ub
                     #reflection
-                    new_points[i] = max(lb,
+                    new_points[i] = max(
+                        lb,
                         maximum(surr1.x) -
-                        norm(new_points[i] - maximum(surr1.x)))
+                            norm(new_points[i] - maximum(surr1.x))
+                    )
                 end
                 if new_points[i] < lb
                     #reflection
-                    new_points[i] = min(ub,
+                    new_points[i] = min(
+                        ub,
                         minimum(surr1.x) +
-                        norm(new_points[i] - minimum(surr1.x)))
+                            norm(new_points[i] - minimum(surr1.x))
+                    )
                 end
             end
         end
@@ -1047,8 +1086,10 @@ function surrogate_optimize!(obj::Function, ::DYCORS, lb::Number, ub::Number,
         end
 
         sigma_n, C_success,
-        C_fail = adjust_step_size(sigma_n, sigma_min, C_success,
-            t_success, C_fail, t_fail)
+            C_fail = adjust_step_size(
+            sigma_n, sigma_min, C_success,
+            t_success, C_fail, t_fail
+        )
 
         if f_new < y_best
             x_best = x_new
@@ -1062,7 +1103,8 @@ end
 
 function select_evaluation_point_ND(
         new_points, surrn::AbstractSurrogate, numb_iters,
-        maxiters)
+        maxiters
+    )
     v = [0.3, 0.5, 0.8, 0.95]
     k = 4
     n = size(surrn.x, 1)
@@ -1083,7 +1125,7 @@ function select_evaluation_point_ND(
     s_min = minimum(evaluations)
     V_nR = zeros(eltype(surrn.y[1]), l)
     for i in 1:l
-        if abs(s_max - s_min) <= 10e-6
+        if abs(s_max - s_min) <= 10.0e-6
             V_nR[i] = 1.0
         else
             V_nR[i] = (evaluations[i] - s_min) / (s_max - s_min)
@@ -1103,7 +1145,7 @@ function select_evaluation_point_ND(
     delta_n_max = maximum(delta_n_x)
     delta_n_min = minimum(delta_n_x)
     for i in 1:l
-        if abs(delta_n_max - delta_n_min) <= 10e-6
+        if abs(delta_n_max - delta_n_min) <= 10.0e-6
             V_nD[i] = 1.0
         else
             V_nD[i] = (delta_n_max - delta_n_x[i]) / (delta_n_max - delta_n_min)
@@ -1131,7 +1173,8 @@ evaluation, so fewer coordinates are perturbed later in the optimization.
 function surrogate_optimize!(
         obj::Function, ::DYCORS, lb, ub, surrn::AbstractSurrogate,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = 100)
+        num_new_samples = 100
+    )
     x_best = collect(surrn.x[argmin(surrn.y)])
     y_best = minimum(surrn.y)
     sigma_n = 0.2 * norm(ub - lb)
@@ -1165,14 +1208,18 @@ function surrogate_optimize!(
             for j in 1:d
                 while new_points[i, j] < lb[j] || new_points[i, j] > ub[j]
                     if new_points[i, j] > ub[j]
-                        new_points[i, j] = max(lb[j],
+                        new_points[i, j] = max(
+                            lb[j],
                             maximum(surrn.x)[j] -
-                            norm(new_points[i, j] - maximum(surrn.x)[j]))
+                                norm(new_points[i, j] - maximum(surrn.x)[j])
+                        )
                     end
                     if new_points[i, j] < lb[j]
-                        new_points[i, j] = min(ub[j],
+                        new_points[i, j] = min(
+                            ub[j],
                             minimum(surrn.x)[j] +
-                            norm(new_points[i] - minimum(surrn.x)[j]))
+                                norm(new_points[i] - minimum(surrn.x)[j])
+                        )
                     end
                 end
             end
@@ -1191,8 +1238,10 @@ function surrogate_optimize!(
         end
 
         sigma_n, C_success,
-        C_fail = adjust_step_size(sigma_n, sigma_min, C_success,
-            t_success, C_fail, t_fail)
+            C_fail = adjust_step_size(
+            sigma_n, sigma_min, C_success,
+            t_success, C_fail, t_fail
+        )
 
         if f_new < y_best
             x_best = x_new
@@ -1237,12 +1286,12 @@ function I_tier_ranking_1D(P, surrSOP::AbstractSurrogate)
                 val1_q = surrSOP.y[q_index]
                 val2_q = obj2_1D(q, P)
                 p_dominates_q = (val1_p < val1_q || abs(val1_p - val1_q) <= 10^-5) &&
-                                (val2_p < val2_q || abs(val2_p - val2_q) <= 10^-5) &&
-                                ((val1_p < val1_q) || (val2_p < val2_q))
+                    (val2_p < val2_q || abs(val2_p - val2_q) <= 10^-5) &&
+                    ((val1_p < val1_q) || (val2_p < val2_q))
 
                 q_dominates_p = (val1_p < val1_q || abs(val1_p - val1_q) < 10^-5) &&
-                                (val2_p < val2_q || abs(val2_p - val2_q) < 10^-5) &&
-                                ((val1_p < val1_q) || (val2_p < val2_q))
+                    (val2_p < val2_q || abs(val2_p - val2_q) < 10^-5) &&
+                    ((val1_p < val1_q) || (val2_p < val2_q))
                 if q_dominates_p
                     n_p += 1
                 end
@@ -1318,9 +1367,11 @@ SOP Surrogate optimization method, following closely the following papers:
 
 #Suggested number of new_samples = min(500*d,5000)
 """
-function surrogate_optimize!(obj::Function, sop1::SOP, lb::Number, ub::Number,
+function surrogate_optimize!(
+        obj::Function, sop1::SOP, lb::Number, ub::Number,
         surrSOP::AbstractSurrogate, sample_type::SamplingAlgorithm;
-        maxiters = 100, num_new_samples = min(500 * 1, 5000))
+        maxiters = 100, num_new_samples = min(500 * 1, 5000)
+    )
     d = length(lb)
     N_fail = 3
     N_tenure = 5
@@ -1524,12 +1575,12 @@ function I_tier_ranking_ND(P, surrSOPD::AbstractSurrogate)
                 val1_q = surrSOPD.y[q_index]
                 val2_q = obj2_ND(q, P)
                 p_dominates_q = (val1_p < val1_q || abs(val1_p - val1_q) <= 10^-5) &&
-                                (val2_p < val2_q || abs(val2_p - val2_q) <= 10^-5) &&
-                                ((val1_p < val1_q) || (val2_p < val2_q))
+                    (val2_p < val2_q || abs(val2_p - val2_q) <= 10^-5) &&
+                    ((val1_p < val1_q) || (val2_p < val2_q))
 
                 q_dominates_p = (val1_p < val1_q || abs(val1_p - val1_q) < 10^-5) &&
-                                (val2_p < val2_q || abs(val2_p - val2_q) < 10^-5) &&
-                                ((val1_p < val1_q) || (val2_p < val2_q))
+                    (val2_p < val2_q || abs(val2_p - val2_q) < 10^-5) &&
+                    ((val1_p < val1_q) || (val2_p < val2_q))
                 if q_dominates_p
                     n_p += 1
                 end
@@ -1568,7 +1619,8 @@ end
 function surrogate_optimize!(
         obj::Function, sopd::SOP, lb, ub, surrSOPD::AbstractSurrogate,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        num_new_samples = min(500 * length(lb), 5000))
+        num_new_samples = min(500 * length(lb), 5000)
+    )
     d = length(lb)
     N_fail = 3
     N_tenure = 5
@@ -1690,7 +1742,7 @@ function surrogate_optimize!(
                     a = lb[k] - C[i][k]
                     b = ub[k] - C[i][k]
                     N_candidates[j, k] = C[i][k] +
-                                         rand(truncated(Normal(0, r_centers[i]), a, b))
+                        rand(truncated(Normal(0, r_centers[i]), a, b))
                 end
                 evaluations[j] = surrSOPD(Tuple(N_candidates[j, :]))
             end
@@ -1720,7 +1772,7 @@ function surrogate_optimize!(
                 Pareto_set[j, 1] = obj(Tuple(Fronts[1][j]))
                 Pareto_set[j, 2] = val
             end
-            if (Hypervolume_Pareto_improving(f_1, f_2, Pareto_set) < tau)#check this
+            if (Hypervolume_Pareto_improving(f_1, f_2, Pareto_set) < tau) #check this
                 #failure
                 r_centers[i] = r_centers[i] / 2
                 N_failures[i] += 1
@@ -1750,9 +1802,12 @@ function _nonDominatedSorting(arr::Array{Float64, 2})
     while !isempty(arr)
         s = size(arr, 1)
         red = dropdims(
-            sum([_dominates(arr[i, :], arr[j, :]) for i in 1:s, j in 1:s],
-                dims = 1) .== 0,
-            dims = 1)
+            sum(
+                [_dominates(arr[i, :], arr[j, :]) for i in 1:s, j in 1:s],
+                dims = 1
+            ) .== 0,
+            dims = 1
+        )
         a = 1:s
         sel::Array{Int64, 1} = a[red]
         push!(fronts, ind[sel])
@@ -1763,9 +1818,11 @@ function _nonDominatedSorting(arr::Array{Float64, 2})
     return fronts
 end
 
-function surrogate_optimize!(obj::Function, sbm::SMB, lb::Number, ub::Number,
+function surrogate_optimize!(
+        obj::Function, sbm::SMB, lb::Number, ub::Number,
         surrSMB::AbstractSurrogate, sample_type::SamplingAlgorithm;
-        maxiters = 100, n_new_look = 1000)
+        maxiters = 100, n_new_look = 1000
+    )
     #obj contains a function for each output dimension
     dim_out = length(surrSMB.y[1])
     d = 1
@@ -1806,7 +1863,8 @@ end
 function surrogate_optimize!(
         obj::Function, smb::SMB, lb, ub, surrSMBND::AbstractSurrogate,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        n_new_look = 1000)
+        n_new_look = 1000
+    )
     #obj contains a function for each output dimension
     dim_out = length(surrSMBND.y[1])
     d = length(lb)
@@ -1845,9 +1903,11 @@ end
 
 # RTEA (Noisy model based multi objective optimization + standard rtea by fieldsen), use this for very noisy objective functions because there are a lot of re-evaluations
 
-function surrogate_optimize!(obj, rtea::RTEA, lb::Number, ub::Number,
+function surrogate_optimize!(
+        obj, rtea::RTEA, lb::Number, ub::Number,
         surrRTEA::AbstractSurrogate, sample_type::SamplingAlgorithm;
-        maxiters = 100, n_new_look = 1000)
+        maxiters = 100, n_new_look = 1000
+    )
     Z = rtea.z
     K = rtea.k
     p_cross = rtea.p
@@ -1954,7 +2014,8 @@ end
 function surrogate_optimize!(
         obj, rtea::RTEA, lb, ub, surrRTEAND::AbstractSurrogate,
         sample_type::SamplingAlgorithm; maxiters = 100,
-        n_new_look = 1000)
+        n_new_look = 1000
+    )
     Z = rtea.z
     K = rtea.k
     p_cross = rtea.p
@@ -2062,8 +2123,9 @@ end
 function surrogate_optimize!(
         obj::Function, ::EI, lb::AbstractArray, ub::AbstractArray, krig,
         sample_type::SectionSample;
-        maxiters = 100, num_new_samples = 100)
-    dtol = 1e-3 * norm(ub - lb)
+        maxiters = 100, num_new_samples = 100
+    )
+    dtol = 1.0e-3 * norm(ub - lb)
     eps = 0.01
     for i in 1:maxiters
         d = length(krig.x)
@@ -2085,14 +2147,14 @@ function surrogate_optimize!(
             for j in 1:length(new_sample)
                 std = std_error_at_point(krig, new_sample[j])
                 u = krig(new_sample[j])
-                if abs(std) > 1e-6
+                if abs(std) > 1.0e-6
                     z = (f_min - u - eps) / std
                 else
                     z = 0
                 end
                 # Evaluate EI at point new_sample[j]
                 evaluations[j] = (f_min - u - eps) * cdf(Normal(), z) +
-                                 std * pdf(Normal(), z)
+                    std * pdf(Normal(), z)
             end
             # find the sample which maximizes the EI function
             index_max = argmax(evaluations)
@@ -2109,8 +2171,10 @@ function surrogate_optimize!(
                 deleteat!(new_sample, index_max)
                 if length(new_sample) == 0
                     println("Out of sampling points.")
-                    return section_sampler_returner(sample_type, krig.x, krig.y, lb, ub,
-                        krig)
+                    return section_sampler_returner(
+                        sample_type, krig.x, krig.y, lb, ub,
+                        krig
+                    )
                 end
             else
                 point_found = true
@@ -2120,22 +2184,26 @@ function surrogate_optimize!(
         end
         # if the EI is less than some tolerance times the difference between the maximum and minimum points
         # in the surrogate, then we terminate the optimizer.
-        if new_EI_max < 1e-6 * norm(maximum(krig.y) - minimum(krig.y))
+        if new_EI_max < 1.0e-6 * norm(maximum(krig.y) - minimum(krig.y))
             println("Termination tolerance reached.")
             return section_sampler_returner(sample_type, krig.x, krig.y, lb, ub, krig)
         end
         update!(krig, Tuple(new_x_max), obj(new_x_max))
     end
-    println("Completed maximum number of iterations.")
+    return println("Completed maximum number of iterations.")
 end
 
-function section_sampler_returner(sample_type::SectionSample, surrn_x, surrn_y,
-        lb, ub, surrn)
+function section_sampler_returner(
+        sample_type::SectionSample, surrn_x, surrn_y,
+        lb, ub, surrn
+    )
     d_fixed = fixed_dimensions(sample_type)
     @assert length(surrn_y) == size(surrn_x)[1]
     surrn_xy = [(surrn_x[y], surrn_y[y]) for y in 1:length(surrn_y)]
-    section_surr1_xy = filter(xyz -> xyz[1][d_fixed] == Tuple(sample_type.x0[d_fixed]),
-        surrn_xy)
+    section_surr1_xy = filter(
+        xyz -> xyz[1][d_fixed] == Tuple(sample_type.x0[d_fixed]),
+        surrn_xy
+    )
     section_surr1_x = [xy[1] for xy in section_surr1_xy]
     section_surr1_y = [xy[2] for xy in section_surr1_xy]
     if length(section_surr1_xy) == 0

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -15,26 +15,30 @@ function sample(args...; kwargs...)
     end
 end
 
-#### SectionSample #### 
+#### SectionSample ####
 """
     SectionSample{T}(x0, sa)
 
 `SectionSample(x0, sampler)` where `sampler` is any sampler above and `x0` is a vector of either `NaN` for a free dimension or some scalar for a constrained dimension.
 """
 struct SectionSample{
-    R <: Real,
-    I <: Integer,
-    VR <: AbstractVector{R},
-    VI <: AbstractVector{I}
-} <: SamplingAlgorithm
+        R <: Real,
+        I <: Integer,
+        VR <: AbstractVector{R},
+        VI <: AbstractVector{I},
+    } <: SamplingAlgorithm
     x0::VR
     sa::SamplingAlgorithm
     fixed_dims::VI
 end
-fixed_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(x -> x == false,
-    isnan.(section_sampler.x0))
-free_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(x -> x == true,
-    isnan.(section_sampler.x0))
+fixed_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(
+    x -> x == false,
+    isnan.(section_sampler.x0)
+)
+free_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(
+    x -> x == true,
+    isnan.(section_sampler.x0)
+)
 """
     sample(n,lb,ub,K::SectionSample)
 
@@ -45,12 +49,15 @@ The sampler is defined as in e.g.
 `section_sampler_y_is_10 = SectionSample([NaN64, NaN64, 10.0, 10.0], UniformSample())`
 where the first argument is a Vector{T} in which numbers are fixed coordinates and `NaN`s correspond to free dimensions, and the second argument is a SamplingAlgorithm which is used to sample in the free dimensions.
 """
-function sample(n::Integer,
+function sample(
+        n::Integer,
         lb::T,
         ub::T,
-        section_sampler::SectionSample) where {
-        T <: Union{Base.AbstractVecOrTuple, Number}}
-    @assert n>0 ZERO_SAMPLES_MESSAGE
+        section_sampler::SectionSample
+    ) where {
+        T <: Union{Base.AbstractVecOrTuple, Number},
+    }
+    @assert n > 0 ZERO_SAMPLES_MESSAGE
     QuasiMonteCarlo._check_sequence(lb, ub, length(lb))
     if lb isa Number
         if isnan(section_sampler.x0[1])
@@ -70,14 +77,18 @@ function sample(n::Integer,
             end
         end
         return isone(size(out_as_vec, 1)) ? vec(out_as_vec) :
-               collect(reinterpret(reshape,
-            NTuple{size(out_as_vec, 1), eltype(out_as_vec)},
-            out_as_vec))
+            collect(
+                reinterpret(
+                    reshape,
+                    NTuple{size(out_as_vec, 1), eltype(out_as_vec)},
+                    out_as_vec
+                )
+            )
     end
 end
 
 function SectionSample(x0::AbstractVector, sa::SamplingAlgorithm)
-    SectionSample(x0, sa, findall(isnan, x0))
+    return SectionSample(x0, sa, findall(isnan, x0))
 end
 
 """
@@ -89,10 +100,12 @@ The sampler is defined
 `SectionSample([NaN64, NaN64, 10.0, 10.0], UniformSample())`
 where the first argument is a Vector{T} in which numbers are fixed coordinates and `NaN`s correspond to free dimensions, and the second argument is a SamplingAlgorithm which is used to sample in the free dimensions.
 """
-function sample(n::Integer,
+function sample(
+        n::Integer,
         d::Integer,
         section_sampler::SectionSample,
-        T = eltype(section_sampler.x0))
+        T = eltype(section_sampler.x0)
+    )
     QuasiMonteCarlo._check_sequence(n)
     @assert eltype(section_sampler.x0) == T
     @assert length(section_sampler.fixed_dims) == d

--- a/src/SecondOrderPolynomialSurrogate.jl
+++ b/src/SecondOrderPolynomialSurrogate.jl
@@ -4,7 +4,7 @@ mutable struct InverseDistanceSurrogate{X,Y,P,L,U} <: AbstractSurrogate
 The square polynomial model can be expressed by 𝐲 = 𝐗β + ϵ, with β = 𝐗ᵗ𝐗⁻¹𝐗ᵗ𝐲
 """
 mutable struct SecondOrderPolynomialSurrogate{X, Y, B, L, U} <:
-               AbstractDeterministicSurrogate
+    AbstractDeterministicSurrogate
     x::X
     y::Y
     β::B
@@ -82,5 +82,5 @@ function SurrogatesBase.update!(my_second::SecondOrderPolynomialSurrogate, x_new
     Y = _construct_y_matrix(my_second.y, first(my_second.y))
     β = X \ Y
     my_second.β = β
-    nothing
+    return nothing
 end

--- a/src/Surrogates.jl
+++ b/src/Surrogates.jl
@@ -6,7 +6,7 @@ using GLM
 using Random
 using ExtendableSparse
 using SurrogatesBase: SurrogatesBase, update!, AbstractDeterministicSurrogate,
-                      AbstractStochasticSurrogate
+    AbstractStochasticSurrogate
 
 include("utils.jl")
 include("Radials.jl")
@@ -24,15 +24,19 @@ include("GEK.jl")
 include("GEKPLS.jl")
 include("VirtualStrategy.jl")
 
-current_surrogates = ["Kriging", "LinearSurrogate", "LobachevskySurrogate",
+current_surrogates = [
+    "Kriging", "LinearSurrogate", "LobachevskySurrogate",
     "NeuralSurrogate",
     "RadialBasis", "XGBoostSurrogate", "SecondOrderPolynomialSurrogate",
-    "Wendland", "GEK", "PolynomialChaosSurrogate"]
+    "Wendland", "GEK", "PolynomialChaosSurrogate",
+]
 
 #Radial structure:
 function RadialBasisStructure(; radial_function, scale_factor, sparse)
-    return (name = "RadialBasis", radial_function = radial_function,
-        scale_factor = scale_factor, sparse = sparse)
+    return (
+        name = "RadialBasis", radial_function = radial_function,
+        scale_factor = scale_factor, sparse = sparse,
+    )
 end
 
 #Kriging structure:
@@ -61,8 +65,10 @@ end
 
 #Neural structure
 function NeuralStructure(; model, loss, opt, n_epochs)
-    return (name = "NeuralSurrogate", model = model, loss = loss, opt = opt,
-        n_epochs = n_epochs)
+    return (
+        name = "NeuralSurrogate", model = model, loss = loss, opt = opt,
+        n_epochs = n_epochs,
+    )
 end
 
 #XGBoost structure
@@ -91,15 +97,15 @@ export current_surrogates
 export GEKPLS
 export RadialBasisStructure, KrigingStructure, LinearStructure, InverseDistanceStructure
 export LobachevskyStructure,
-       NeuralStructure, XGBoostStructure,
-       SecondOrderPolynomialStructure
+    NeuralStructure, XGBoostStructure,
+    SecondOrderPolynomialStructure
 export WendlandStructure
 export SamplingAlgorithm
 export Kriging, RadialBasis, std_error_at_point
 # Parallelization Strategies
 export potential_optimal_points
 export MinimumConstantLiar, MaximumConstantLiar, MeanConstantLiar, KrigingBeliever,
-       KrigingBelieverUpperBound, KrigingBelieverLowerBound
+    KrigingBelieverUpperBound, KrigingBelieverLowerBound
 export update!
 
 # radial basis functions
@@ -107,7 +113,7 @@ export linearRadial, cubicRadial, multiquadricRadial, thinplateRadial
 
 # samplers
 export sample, GridSample, RandomSample, SobolSample, LatinHypercubeSample,
-       HaltonSample
+    HaltonSample
 export RandomSample, KroneckerSample, GoldenSample, SectionSample
 
 # Optimization algorithms
@@ -119,8 +125,8 @@ export SecondOrderPolynomialSurrogate
 export Wendland
 export RadialBasisStructure, KrigingStructure, LinearStructure, InverseDistanceStructure
 export LobachevskyStructure,
-       NeuralStructure, XGBoostStructure,
-       SecondOrderPolynomialStructure
+    NeuralStructure, XGBoostStructure,
+    SecondOrderPolynomialStructure
 export WendlandStructure
 #export MOE
 export VariableFidelitySurrogate

--- a/src/VariableFidelity.jl
+++ b/src/VariableFidelity.jl
@@ -1,5 +1,5 @@
 mutable struct VariableFidelitySurrogate{X, Y, L, U, N, F, E} <:
-               AbstractDeterministicSurrogate
+    AbstractDeterministicSurrogate
     x::X
     y::Y
     lb::L
@@ -9,14 +9,20 @@ mutable struct VariableFidelitySurrogate{X, Y, L, U, N, F, E} <:
     eps_surr::E
 end
 
-function VariableFidelitySurrogate(x, y, lb, ub;
+function VariableFidelitySurrogate(
+        x, y, lb, ub;
         num_high_fidel = Int(floor(length(x) / 2)),
-        low_fid_structure = RadialBasisStructure(radial_function = linearRadial(),
+        low_fid_structure = RadialBasisStructure(
+            radial_function = linearRadial(),
             scale_factor = 1.0,
-            sparse = false),
-        high_fid_structure = RadialBasisStructure(radial_function = cubicRadial(),
+            sparse = false
+        ),
+        high_fid_structure = RadialBasisStructure(
+            radial_function = cubicRadial(),
             scale_factor = 1.0,
-            sparse = false))
+            sparse = false
+        )
+    )
     x_high = x[1:num_high_fidel]
     x_low = x[(num_high_fidel + 1):end]
     y_high = y[1:num_high_fidel]
@@ -25,49 +31,65 @@ function VariableFidelitySurrogate(x, y, lb, ub;
     #Fit low fidelity surrogate:
     if low_fid_structure[1] == "RadialBasis"
         #fit and append to local_surr
-        low_fid_surr = RadialBasis(x_low, y_low, lb, ub,
+        low_fid_surr = RadialBasis(
+            x_low, y_low, lb, ub,
             rad = low_fid_structure.radial_function,
             scale_factor = low_fid_structure.scale_factor,
-            sparse = low_fid_structure.sparse)
+            sparse = low_fid_structure.sparse
+        )
 
     elseif low_fid_structure[1] == "Kriging"
-        low_fid_surr = Kriging(x_low, y_low, lb, ub, p = low_fid_structure.p,
-            theta = low_fid_structure.theta)
+        low_fid_surr = Kriging(
+            x_low, y_low, lb, ub, p = low_fid_structure.p,
+            theta = low_fid_structure.theta
+        )
 
     elseif low_fid_structure[1] == "GEK"
-        low_fid_surr = GEK(x_low, y_low, lb, ub, p = low_fid_structure.p,
-            theta = low_fid_structure.theta)
+        low_fid_surr = GEK(
+            x_low, y_low, lb, ub, p = low_fid_structure.p,
+            theta = low_fid_structure.theta
+        )
 
     elseif low_fid_structure == "LinearSurrogate"
         low_fid_surr = LinearSurrogate(x_low, y_low, lb, ub)
 
     elseif low_fid_structure[1] == "InverseDistanceSurrogate"
-        low_fid_surr = InverseDistanceSurrogate(x_low, y_low, lb, ub,
-            p = low_fid_structure.p)
+        low_fid_surr = InverseDistanceSurrogate(
+            x_low, y_low, lb, ub,
+            p = low_fid_structure.p
+        )
 
     elseif low_fid_structure[1] == "LobachevskySurrogate"
-        low_fid_surr = LobachevskySurrogate(x_low, y_low, lb, ub,
+        low_fid_surr = LobachevskySurrogate(
+            x_low, y_low, lb, ub,
             alpha = low_fid_structure.alpha,
             n = low_fid_structure.n,
-            sparse = low_fid_structure.sparse)
+            sparse = low_fid_structure.sparse
+        )
 
     elseif low_fid_structure[1] == "NeuralSurrogate"
-        low_fid_surr = NeuralSurrogate(x_low, y_low, lb, ub,
+        low_fid_surr = NeuralSurrogate(
+            x_low, y_low, lb, ub,
             model = low_fid_structure.model,
             loss = low_fid_structure.loss,
             opt = low_fid_structure.opt,
-            n_epochs = low_fid_structure.n_epochs)
+            n_epochs = low_fid_structure.n_epochs
+        )
 
     elseif low_fid_structure[1] == "XGBoostSurrogate"
-        low_fid_surr = XGBoostSurrogate(x_low, y_low, lb, ub,
-            num_round = low_fid_structure.num_round)
+        low_fid_surr = XGBoostSurrogate(
+            x_low, y_low, lb, ub,
+            num_round = low_fid_structure.num_round
+        )
 
     elseif low_fid_structure == "SecondOrderPolynomialSurrogate"
         low_fid_surr = SecondOrderPolynomialSurrogate(x_low, y_low, lb, ub)
 
     elseif low_fid_structure[1] == "Wendland"
-        low_fid_surr = Wendand(x_low, y_low, lb, ub, eps = low_fid_surr.eps,
-            maxiters = low_fid_surr.maxiters, tol = low_fid_surr.tol)
+        low_fid_surr = Wendand(
+            x_low, y_low, lb, ub, eps = low_fid_surr.eps,
+            maxiters = low_fid_surr.maxiters, tol = low_fid_surr.tol
+        )
     else
         throw("A surrogate with the name provided does not exist or is not currently supported with VariableFidelity")
     end
@@ -80,13 +102,17 @@ function VariableFidelitySurrogate(x, y, lb, ub;
 
     if high_fid_structure[1] == "RadialBasis"
         #fit and append to local_surr
-        eps = RadialBasis(x_high, y_eps, lb, ub, rad = high_fid_structure.radial_function,
+        eps = RadialBasis(
+            x_high, y_eps, lb, ub, rad = high_fid_structure.radial_function,
             scale_factor = high_fid_structure.scale_factor,
-            sparse = high_fid_structure.sparse)
+            sparse = high_fid_structure.sparse
+        )
 
     elseif high_fid_structure[1] == "Kriging"
-        eps = Kriging(x_high, y_eps, lb, ub, p = high_fid_structure.p,
-            theta = high_fid_structure.theta)
+        eps = Kriging(
+            x_high, y_eps, lb, ub, p = high_fid_structure.p,
+            theta = high_fid_structure.theta
+        )
 
     elseif high_fid_structure == "LinearSurrogate"
         eps = LinearSurrogate(x_high, y_eps, lb, ub)
@@ -95,25 +121,33 @@ function VariableFidelitySurrogate(x, y, lb, ub;
         eps = InverseDistanceSurrogate(x_high, y_eps, lb, ub, high_fid_structure.p)
 
     elseif high_fid_structure[1] == "LobachevskySurrogate"
-        eps = LobachevskySurrogate(x_high, y_eps, lb, ub, alpha = high_fid_structure.alpha,
+        eps = LobachevskySurrogate(
+            x_high, y_eps, lb, ub, alpha = high_fid_structure.alpha,
             n = high_fid_structure.n,
-            sparse = high_fid_structure.sparse)
+            sparse = high_fid_structure.sparse
+        )
 
     elseif high_fid_structure[1] == "NeuralSurrogate"
-        eps = NeuralSurrogate(x_high, y_eps, lb, ub, model = high_fid_structure.model,
+        eps = NeuralSurrogate(
+            x_high, y_eps, lb, ub, model = high_fid_structure.model,
             loss = high_fid_structure.loss, opt = high_fid_structure.opt,
-            n_epochs = high_fid_structure.n_epochs)
+            n_epochs = high_fid_structure.n_epochs
+        )
 
     elseif high_fid_structure[1] == "XGBoostSurrogate"
-        eps = XGBoostSurrogate(x_high, y_eps, lb, ub,
-            num_round = high_fid_structure.num_round)
+        eps = XGBoostSurrogate(
+            x_high, y_eps, lb, ub,
+            num_round = high_fid_structure.num_round
+        )
 
     elseif high_fid_structure == "SecondOrderPolynomialSurrogate"
         eps = SecondOrderPolynomialSurrogate(x_high, y_eps, lb, ub)
 
     elseif high_fid_structure[1] == "Wendland"
-        eps = Wendand(x_high, y_eps, lb, ub, eps = high_fid_structure.eps,
-            maxiters = high_fid_structure.maxiters, tol = high_fid_structure.tol)
+        eps = Wendand(
+            x_high, y_eps, lb, ub, eps = high_fid_structure.eps,
+            maxiters = high_fid_structure.maxiters, tol = high_fid_structure.tol
+        )
     else
         throw("A surrogate with the name provided does not exist or is not currently supported with VariableFidelity")
     end
@@ -150,7 +184,7 @@ update!(varfid::VariableFidelitySurrogate,x_new,y_new)
 I expect to add low fidelity data to the surrogate.
 """
 function SurrogatesBase.update!(varfid::VariableFidelitySurrogate, x_new, y_new)
-    if length(varfid.x[1]) == 1
+    return if length(varfid.x[1]) == 1
         #1D
         varfid.x = vcat(varfid.x, x_new)
         varfid.y = vcat(varfid.y, y_new)

--- a/src/VirtualStrategy.jl
+++ b/src/VirtualStrategy.jl
@@ -1,44 +1,50 @@
-# Minimum Constant Liar 
-function calculate_liars(::MinimumConstantLiar,
+# Minimum Constant Liar
+function calculate_liars(
+        ::MinimumConstantLiar,
         tmp_surr::AbstractSurrogate,
         surr::AbstractSurrogate,
-        new_x)
+        new_x
+    )
     new_y = minimum(surr.y)
-    update!(tmp_surr, new_x, new_y)
+    return update!(tmp_surr, new_x, new_y)
 end
 
 # Maximum Constant Liar
-function calculate_liars(::MaximumConstantLiar,
+function calculate_liars(
+        ::MaximumConstantLiar,
         tmp_surr::AbstractSurrogate,
         surr::AbstractSurrogate,
-        new_x)
+        new_x
+    )
     new_y = maximum(surr.y)
-    update!(tmp_surr, new_x, new_y)
+    return update!(tmp_surr, new_x, new_y)
 end
 
 # Mean Constant Liar
-function calculate_liars(::MeanConstantLiar,
+function calculate_liars(
+        ::MeanConstantLiar,
         tmp_surr::AbstractSurrogate,
         surr::AbstractSurrogate,
-        new_x)
+        new_x
+    )
     new_y = mean(surr.y)
-    update!(tmp_surr, new_x, new_y)
+    return update!(tmp_surr, new_x, new_y)
 end
 
 # Kriging Believer
 function calculate_liars(::KrigingBeliever, tmp_k::Kriging, k::Kriging, new_x)
     new_y = k(new_x)
-    update!(tmp_k, new_x, new_y)
+    return update!(tmp_k, new_x, new_y)
 end
 
 # Kriging Believer Upper Bound
 function calculate_liars(::KrigingBelieverUpperBound, tmp_k::Kriging, k::Kriging, new_x)
     new_y = k(new_x) + 3 * std_error_at_point(k, new_x)
-    update!(tmp_k, new_x, new_y)
+    return update!(tmp_k, new_x, new_y)
 end
 
 # Kriging Believer Lower Bound
 function calculate_liars(::KrigingBelieverLowerBound, tmp_k::Kriging, k::Kriging, new_x)
     new_y = k(new_x) - 3 * std_error_at_point(k, new_x)
-    update!(tmp_k, new_x, new_y)
+    return update!(tmp_k, new_x, new_y)
 end

--- a/src/Wendland.jl
+++ b/src/Wendland.jl
@@ -44,7 +44,7 @@ function _calc_coeffs_wend(x, y, eps, maxiters, tol)
     return cg(U, y, maxiter = maxiters, reltol = tol)
 end
 
-function Wendland(x, y, lb, ub; eps = 1.0, maxiters = 300, tol = 1e-6)
+function Wendland(x, y, lb, ub; eps = 1.0, maxiters = 300, tol = 1.0e-6)
     c = _calc_coeffs_wend(x, y, eps, maxiters, tol)
     return Wendland(x, y, lb, ub, c, maxiters, tol, eps)
 end
@@ -53,13 +53,15 @@ function (wend::Wendland)(val)
     # Check to make sure dimensions of input matches expected dimension of surrogate
     _check_dimension(wend, val)
 
-    return sum(wend.coeff[j] * _wendland(val .- wend.x[j], wend.eps)
-    for j in 1:length(wend.coeff))
+    return sum(
+        wend.coeff[j] * _wendland(val .- wend.x[j], wend.eps)
+            for j in 1:length(wend.coeff)
+    )
 end
 
 function SurrogatesBase.update!(wend::Wendland, new_x, new_y)
     if (length(new_x) == 1 && length(new_x[1]) == 1) ||
-       (length(new_x) > 1 && length(new_x[1]) == 1 && length(wend.lb) > 1)
+            (length(new_x) > 1 && length(new_x[1]) == 1 && length(wend.lb) > 1)
         push!(wend.x, new_x)
         push!(wend.y, new_y)
     else
@@ -67,5 +69,5 @@ function SurrogatesBase.update!(wend::Wendland, new_x, new_y)
         append!(wend.y, new_y)
     end
     wend.coeff = _calc_coeffs_wend(wend.x, wend.y, wend.eps, wend.maxiters, wend.tol)
-    nothing
+    return nothing
 end

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -24,7 +24,7 @@ mutable struct NeuralSurrogate{X, Y, M, L, O, P, N, A, U} <: AbstractDeterminist
 end
 
 mutable struct PolynomialChaosSurrogate{X, Y, L, U, C, O, N} <:
-               AbstractDeterministicSurrogate
+    AbstractDeterministicSurrogate
     x::X
     y::Y
     lb::L
@@ -35,7 +35,7 @@ mutable struct PolynomialChaosSurrogate{X, Y, L, U, C, O, N} <:
 end
 
 mutable struct XGBoostSurrogate{X, Y, B, L, U, N} <:
-               SurrogatesBase.AbstractDeterministicSurrogate
+    SurrogatesBase.AbstractDeterministicSurrogate
     x::X
     y::Y
     bst::B

--- a/test/AD_compatibility.jl
+++ b/test/AD_compatibility.jl
@@ -20,7 +20,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.derivative(my_rad, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #Kriging
@@ -30,7 +30,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.derivative(my_krig, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #Linear Surrogate
@@ -60,7 +60,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.derivative(my_loba, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #Second order polynomial
@@ -69,7 +69,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.derivative(my_second, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #Wendland
@@ -102,11 +102,12 @@ using GaussianMixtures
             extra_points = 1
             initial_theta = [0.01 for i in 1:n_comp]
             my_gekpls = GEKPLS(
-                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
+                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta
+            )
             g = x -> ForwardDiff.derivative(my_gekpls, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #Earth
@@ -124,20 +125,20 @@ using GaussianMixtures
             g = x -> ForwardDiff.derivative(my_varfid, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
 
         #MOE
         @testset "MOE" begin
             expert_types = [
                 RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0, sparse = false),
-                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false)
+                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false),
             ]
             my_moe = MOE(x, y, expert_types, ndim = 1, n_clusters = 2)
             g = x -> ForwardDiff.derivative(my_moe, x)
             @test g(5.0) isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(g(5.0), 10.0, atol = 1e-1)
+            @test isapprox(g(5.0), 10.0, atol = 1.0e-1)
         end
     end
 
@@ -155,7 +156,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.gradient(my_rad, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #Kriging
@@ -166,7 +167,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.gradient(my_krig, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #Linear Surrogate
@@ -196,7 +197,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.gradient(my_loba_ND, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #Second order polynomial
@@ -205,7 +206,7 @@ using GaussianMixtures
             g = x -> ForwardDiff.gradient(my_second, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #Wendland
@@ -238,11 +239,12 @@ using GaussianMixtures
             extra_points = 2
             initial_theta = [0.01 for i in 1:n_comp]
             my_gekpls_ND = GEKPLS(
-                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
+                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta
+            )
             g = x -> ForwardDiff.gradient(my_gekpls_ND, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #Earth
@@ -260,20 +262,20 @@ using GaussianMixtures
             g = x -> ForwardDiff.gradient(my_varfid_ND, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
 
         #MOE
         @testset "MOE" begin
             expert_types = [
                 RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0, sparse = false),
-                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false)
+                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false),
             ]
             my_moe_ND = MOE(x, y, expert_types, ndim = 2, n_clusters = 2)
             g = x -> ForwardDiff.gradient(my_moe_ND, x)
             @test g([2.0, 5.0]) isa AbstractVector
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1e-1)
+            @test isapprox(g([2.0, 5.0]), [5.0, 2.0], atol = 1.0e-1)
         end
     end
 end
@@ -296,7 +298,7 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #Kriging
@@ -309,7 +311,7 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #Linear Surrogate
@@ -348,7 +350,7 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #Second order polynomial
@@ -360,7 +362,7 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #Wendland
@@ -399,14 +401,15 @@ end
             extra_points = 2
             initial_theta = [0.01 for i in 1:n_comp]
             my_gekpls = GEKPLS(
-                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
+                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta
+            )
             g = x -> Zygote.gradient(my_gekpls, x)
             result = g(5.0)
             @test result isa Tuple
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #Earth
@@ -430,14 +433,14 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
 
         #MOE
         @testset "MOE" begin
             expert_types = [
                 RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0, sparse = false),
-                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false)
+                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false),
             ]
             my_moe = MOE(x, y, expert_types, ndim = 1, n_clusters = 2)
             g = x -> Zygote.gradient(my_moe, x)
@@ -446,7 +449,7 @@ end
             @test length(result) == 1
             @test result[1] isa Number
             # Accuracy test: f(x) = x^2, f'(x) = 2x, so f'(5.0) = 10.0
-            @test isapprox(result[1], 10.0, atol = 1e-1)
+            @test isapprox(result[1], 10.0, atol = 1.0e-1)
         end
     end
 
@@ -467,7 +470,7 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #Kriging
@@ -481,7 +484,7 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #Linear Surrogate
@@ -520,7 +523,7 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #Second order polynomial
@@ -532,7 +535,7 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #Wendland
@@ -571,14 +574,15 @@ end
             extra_points = 2
             initial_theta = [0.01 for i in 1:n_comp]
             my_gekpls_ND = GEKPLS(
-                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
+                x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta
+            )
             g = x -> Zygote.gradient(my_gekpls_ND, x)
             result = g((2.0, 5.0))
             @test result isa Tuple
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #Earth
@@ -602,14 +606,14 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
 
         #MOE
         @testset "MOE" begin
             expert_types = [
                 RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0, sparse = false),
-                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false)
+                RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0, sparse = false),
             ]
             my_moe_ND = MOE(x, y, expert_types, ndim = 2, n_clusters = 2)
             g = x -> Zygote.gradient(my_moe_ND, x)
@@ -618,7 +622,7 @@ end
             @test length(result) == 1
             @test result[1] isa Tuple
             # Accuracy test: f(x) = x[1] * x[2], ∇f = [x[2], x[1]], so ∇f([2.0, 5.0]) = [5.0, 2.0]
-            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1e-1))
+            @test all(isapprox.(result[1], (5.0, 2.0), atol = 1.0e-1))
         end
     end
 end

--- a/test/GEKPLS.jl
+++ b/test/GEKPLS.jl
@@ -13,7 +13,7 @@ function water_flow(x)
     K_w = x[8]
     log_val = log(r / r_w)
     return (2 * pi * T_u * (H_u - H_l)) /
-           (log_val * (1 + (2 * L * T_u / (log_val * r_w^2 * K_w)) + T_u / T_l))
+        (log_val * (1 + (2 * L * T_u / (log_val * r_w^2 * K_w)) + T_u / T_l))
 end
 
 n = 1000
@@ -88,7 +88,7 @@ y_true = welded_beam.(x_test)
     g = GEKPLS(x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
     y_pred = g.(x_test)
     rmse = sqrt(sum(((y_pred - y_true) .^ 2) / n_test))
-    @test isapprox(rmse, 50.0, atol = 0.5)#rmse: 38.988
+    @test isapprox(rmse, 50.0, atol = 0.5) #rmse: 38.988
 end
 
 @testset "Test 5: Welded Beam Function Test (dimensions = 3; n_comp = 2; extra_points = 2)" begin
@@ -174,9 +174,11 @@ end
     delta_x = 0.0001
     extra_points = 2
     initial_theta = [0.01 for i in 1:n_comp]
-    g = GEKPLS(initial_x_vec, initial_y, initial_grads, n_comp, delta_x, lb, ub,
+    g = GEKPLS(
+        initial_x_vec, initial_y, initial_grads, n_comp, delta_x, lb, ub,
         extra_points,
-        initial_theta)
+        initial_theta
+    )
     n_test = 100
     x_test = sample(n_test, lb, ub, GoldenSample())
     y_true = sphere_function.(x_test)
@@ -209,9 +211,11 @@ end
     y = sphere_function.(x)
     g = GEKPLS(x, y, grads, n_comp, delta_x, lb, ub, extra_points, initial_theta)
     x_point,
-    minima = surrogate_optimize!(sphere_function, SRBF(), lb, ub, g,
+        minima = surrogate_optimize!(
+        sphere_function, SRBF(), lb, ub, g,
         RandomSample(); maxiters = 20,
-        num_new_samples = 20, needs_gradient = true)
+        num_new_samples = 20, needs_gradient = true
+    )
     @test isapprox(minima, 0.0, atol = 0.0001)
 end
 

--- a/test/Kriging.jl
+++ b/test/Kriging.jl
@@ -12,9 +12,9 @@ y = f.(x)
 my_p = 1.9
 
 # Check hyperparameter validation for constructing 1D Kriging surrogates
-@test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = -1.0)
-@test_throws ArgumentError my_k=Kriging(x, y, lb, ub, p = 3.0)
-@test_throws ArgumentError my_k=Kriging(x, y, lb, ub, theta = -2.0)
+@test_throws ArgumentError my_k = Kriging(x, y, lb, ub, p = -1.0)
+@test_throws ArgumentError my_k = Kriging(x, y, lb, ub, p = 3.0)
+@test_throws ArgumentError my_k = Kriging(x, y, lb, ub, theta = -2.0)
 
 my_k = Kriging(x, y, lb, ub, p = my_p)
 @test my_k.theta ≈ 0.5 * std(x)^(-my_p)
@@ -29,7 +29,7 @@ pred = my_k(5.5)
 
 @test 238.86 ≤ pred ≤ 722.84
 @test my_k(5.0) ≈ 238.86
-@test std_error_at_point(my_k, 5.0) < 1e-3 * my_k(5.0)
+@test std_error_at_point(my_k, 5.0) < 1.0e-3 * my_k(5.0)
 
 #WITHOUT ADD POINT
 x = [1.0, 2.0, 3.0]

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -157,17 +157,17 @@ mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(0.9)) # different sh
 
 # Issue 316
 
-x = sample(1024, [-0.45, -0.4, -0.9], [0.40, 0.55, 0.35], SobolSample())
+x = sample(1024, [-0.45, -0.4, -0.9], [0.4, 0.55, 0.35], SobolSample())
 lb = [-0.45 -0.4 -0.9]
-ub = [0.40 0.55 0.35]
+ub = [0.4 0.55 0.35]
 
 function mockvalues(in)
     x, y, z = in
-    p1 = reverse(vec([1.09903695e+01 -1.01500500e+01 -4.06629740e+01 -1.41834931e+01 1.00604784e+01 4.34951623e+00 -1.06519689e-01 -1.93335202e-03]))
+    p1 = reverse(vec([1.09903695e+1 -1.015005e+1 -4.0662974e+1 -1.41834931e+1 1.00604784e+1 4.34951623e+0 -1.06519689e-1 -1.93335202e-3]))
     p2 = vec([2.12791877 2.12791877 4.23881665 -1.05464575])
     f = evalpoly(z, p1)
     f += p2[1] * x^2 + p2[2] * y^2 + p2[3] * x^2 * y + p2[4] * x * y^2
-    f
+    return f
 end
 
 y = mockvalues.(x)
@@ -182,7 +182,7 @@ lb = 0.0
 ub = 4.0
 x = [1.0, 2.0, 3.0]
 y = [4.0, 5.0, 6.0]
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = 1E-12)
+my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = 1.0e-12)
 est = my_rad(3.0)
 @test est ≈ 6.0
 update!(my_rad, 4.0, 10.0)
@@ -206,14 +206,15 @@ y = [4.0, 5.0, 6.0]
 lb = [0.0, 3.0, 6.0]
 ub = [4.0, 7.0, 10.0]
 my_rad = RadialBasis(
-    x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0, regularization = 1E-12)
+    x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0, regularization = 1.0e-12
+)
 update!(my_rad, (9.0, 10.0, 11.0), 10.0)
 est = my_rad((1.0, 2.0, 3.0))
 @test est ≈ 4.0
 
 # Check regularization fixes the SingularException
 # 1D
-for reg in [0, 1E-12]
+for reg in [0, 1.0e-12]
     local lb = 0.0
     local ub = 4.0
     # Pass the first point twice to create a singular matrix
@@ -222,7 +223,8 @@ for reg in [0, 1E-12]
     local y = [4.0, 4.0, 5.0, 6.0]
     if reg == 0
         @test_throws LinearAlgebra.SingularException RadialBasis(
-            x, y, lb, ub, rad = linearRadial(), regularization = reg)
+            x, y, lb, ub, rad = linearRadial(), regularization = reg
+        )
     else
         local my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = reg)
         @test my_rad(3.0) ≈ 6.0
@@ -231,14 +233,15 @@ for reg in [0, 1E-12]
 end
 
 # ND
-for reg in [0, 1E-12]
+for reg in [0, 1.0e-12]
     local lb = [0.0, 3.0, 6.0]
     local ub = [4.0, 7.0, 10.0]
     local x = [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
     local y = [4.0, 4.0, 5.0, 6.0]
     if reg == 0
         @test_throws LinearAlgebra.SingularException RadialBasis(
-            x, y, lb, ub, rad = linearRadial(), regularization = reg)
+            x, y, lb, ub, rad = linearRadial(), regularization = reg
+        )
     else
         local my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = reg)
         @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0

--- a/test/SectionSampleTests.jl
+++ b/test/SectionSampleTests.jl
@@ -24,28 +24,36 @@ isapprox(f([0, 0, 0]), f_hat([0, 0, 0]))
 
 """ The global minimum is at (0,0) """
 
-(xy_min, f_hat_min) = surrogate_optimize!(f,
+(xy_min, f_hat_min) = surrogate_optimize!(
+    f,
     DYCORS(), lb, ub,
     f_hat,
-    SobolSample())
+    SobolSample()
+)
 
-isapprox(xy_min[1], 0.0, atol = 1e-1)
+isapprox(xy_min[1], 0.0, atol = 1.0e-1)
 
 """ The minimum on the (0,10) section is around (0,10) """
 
-section_sampler_z_is_10 = SectionSample([NaN64, NaN64, 10.0],
-    Surrogates.RandomSample())
+section_sampler_z_is_10 = SectionSample(
+    [NaN64, NaN64, 10.0],
+    Surrogates.RandomSample()
+)
 
 @test [3] == Surrogates.fixed_dimensions(section_sampler_z_is_10)
 @test [1, 2] == Surrogates.free_dimensions(section_sampler_z_is_10)
 
 Surrogates.sample(5, lb, ub, section_sampler_z_is_10)
 
-(xy_min,
-    f_hat_min) = surrogate_optimize!(f,
+(
+    xy_min,
+    f_hat_min,
+) = surrogate_optimize!(
+    f,
     EI(), lb, ub,
     f_hat,
-    section_sampler_z_is_10, maxiters = 1000)
+    section_sampler_z_is_10, maxiters = 1000
+)
 
 isapprox(xy_min[1], 0.0, atol = 0.1)
 isapprox(xy_min[2], 0.0, atol = 0.1)

--- a/test/VariableFidelity.jl
+++ b/test/VariableFidelity.jl
@@ -12,11 +12,15 @@ val = my_varfid(3.0)
 update!(my_varfid, 3.0, 6.0)
 val = my_varfid(3.0)
 
-my_varfid_change_struct = VariableFidelitySurrogate(x, y, lb, ub, num_high_fidel = 2,
+my_varfid_change_struct = VariableFidelitySurrogate(
+    x, y, lb, ub, num_high_fidel = 2,
     low_fid_structure = InverseDistanceStructure(p = 1.0),
-    high_fid_structure = RadialBasisStructure(radial_function = linearRadial(),
+    high_fid_structure = RadialBasisStructure(
+        radial_function = linearRadial(),
         scale_factor = 1.0,
-        sparse = false))
+        sparse = false
+    )
+)
 #ND
 n = 10
 lb = [0.0, 0.0]
@@ -27,8 +31,12 @@ y = f.(x)
 my_varfidND = VariableFidelitySurrogate(x, y, lb, ub)
 val = my_varfidND((2.0, 2.0))
 update!(my_varfidND, (3.0, 3.0), 9.0)
-my_varfidND_change_struct = VariableFidelitySurrogate(x, y, lb, ub, num_high_fidel = 2,
+my_varfidND_change_struct = VariableFidelitySurrogate(
+    x, y, lb, ub, num_high_fidel = 2,
     low_fid_structure = InverseDistanceStructure(p = 1.0),
-    high_fid_structure = RadialBasisStructure(radial_function = linearRadial(),
+    high_fid_structure = RadialBasisStructure(
+        radial_function = linearRadial(),
         scale_factor = 1.0,
-        sparse = false))
+        sparse = false
+    )
+)

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -24,8 +24,10 @@ using SafeTestsets, Test
         f = x -> x^2
         x_points = sample(5, lb, ub, SobolSample())
         y_points = f.(x_points)
-        agp1D = AbstractGPSurrogate([x_points[1]], [y_points[1]],
-            gp = GP(SqExponentialKernel()), Σy = 0.05)
+        agp1D = AbstractGPSurrogate(
+            [x_points[1]], [y_points[1]],
+            gp = GP(SqExponentialKernel()), Σy = 0.05
+        )
         x_new = 2.5
         y_actual = f.(x_new)
         for i in 2:length(x_points)
@@ -72,7 +74,7 @@ using SafeTestsets, Test
         y = f.(x)
         agpND = AbstractGPSurrogate(x, y, gp = GP(SqExponentialKernel()), Σy = 0.05)
         x_new = (-0.8, 0.8, 0.8)
-        @test agpND(x_new)≈f(x_new) atol=0.2
+        @test agpND(x_new) ≈ f(x_new) atol = 0.2
     end
 
     @testset "check working of logpdf_surrogate 1D" begin
@@ -106,7 +108,7 @@ using SafeTestsets, Test
             agp1D = AbstractGPSurrogate(x, y, gp = GP(SqExponentialKernel()), Σy = 0.05)
             g = x -> Zygote.gradient(agp1D, x)
             x_val = 2.0
-            @test g(x_val)[1]≈2 * x_val rtol=1e-1
+            @test g(x_val)[1] ≈ 2 * x_val rtol = 1.0e-1
         end
         @testset "ND" begin
             lb = [0.0, 0.0]
@@ -119,8 +121,8 @@ using SafeTestsets, Test
             g = x -> Zygote.gradient(my_agp, x)
             x_val = (2.0, 5.0)
             g_val = g(x_val)[1]
-            @test g_val[1]≈x_val[2] rtol=1e-1
-            @test g_val[2]≈x_val[1] rtol=1e-1
+            @test g_val[1] ≈ x_val[2] rtol = 1.0e-1
+            @test g_val[2] ≈ x_val[1] rtol = 1.0e-1
         end
     end
 end
@@ -153,8 +155,10 @@ end
         y = obj_ND_neural.(x)
         my_model = Chain(Dense(2, 1))
         my_opt = Descent(0.01)
-        my_neural = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        my_neural = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
         my_neural_kwargs = NeuralSurrogate(x, y, lb, ub, model = my_model)
         my_neural([3.4, 1.4])
         update!(my_neural, [[3.5, 1.4]], [4.9])
@@ -169,8 +173,10 @@ end
         y = f.(x)
         my_model = Chain(Dense(1, 2))
         my_opt = Descent(0.01)
-        surrogate = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        surrogate = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
 
         f = x -> [x[1], x[2]^2]
         lb = [1.0, 2.0]
@@ -179,8 +185,10 @@ end
         y = f.(x)
         my_model = Chain(Dense(2, 2))
         my_opt = Descent(0.01)
-        surrogate = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        surrogate = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
         surrogate([1.0, 2.0])
         x_new = [[2.0, 2.0]]
         y_new = [f(x_new[1])]
@@ -195,8 +203,10 @@ end
         y = objective_function_1D.(x)
         model = Chain(Dense(1, 1), first)
         my_neural_1D_neural = NeuralSurrogate(x, y, lb, ub, model = model)
-        surrogate_optimize!(objective_function_1D, SRBF(), lb, ub, my_neural_1D_neural,
-            SobolSample(), maxiters = 15)
+        surrogate_optimize!(
+            objective_function_1D, SRBF(), lb, ub, my_neural_1D_neural,
+            SobolSample(), maxiters = 15
+        )
     end
 
     @testset "ND Optimization" begin
@@ -208,8 +218,10 @@ end
         model = Chain(Dense(2, 1), first)
         opt = Descent(0.01)
         my_neural_ND_neural = NeuralSurrogate(x, y, lb, ub, model = model, loss = Flux.mse)
-        surrogate_optimize!(objective_function_ND, SRBF(), lb, ub, my_neural_ND_neural,
-            SobolSample(), maxiters = 15)
+        surrogate_optimize!(
+            objective_function_ND, SRBF(), lb, ub, my_neural_ND_neural,
+            SobolSample(), maxiters = 15
+        )
     end
 
     # AD Compatibility
@@ -223,8 +235,10 @@ end
     @testset "NN" begin
         my_model = Chain(Dense(1, 1), first)
         my_opt = Descent(0.01)
-        my_neural = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        my_neural = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
         g = x -> my_neural'(x)
         g(3.4)
     end
@@ -240,8 +254,10 @@ end
     @testset "NN ND" begin
         my_model = Chain(Dense(2, 1), first)
         my_opt = Descent(0.01)
-        my_neural = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        my_neural = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
         g = x -> Zygote.gradient(my_neural, x)
         g([2.0, 5.0])
     end
@@ -259,8 +275,10 @@ end
     @testset "NN ND -> ND" begin
         my_model = Chain(Dense(2, 2))
         my_opt = Descent(0.01)
-        my_neural = NeuralSurrogate(x, y, lb, ub, model = my_model, loss = Flux.mse,
-            opt = my_opt, n_epochs = 1)
+        my_neural = NeuralSurrogate(
+            x, y, lb, ub, model = my_model, loss = Flux.mse,
+            opt = my_opt, n_epochs = 1
+        )
         Zygote.gradient(x -> sum(my_neural(x)), [2.0, 5.0])
 
         my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial())
@@ -293,7 +311,8 @@ end
         @test my_pce(x_val) ≈ f(x_val)
         update!(my_pce, [3.0], [6.0])
         my_pce_changed = PolynomialChaosSurrogate(
-            x, y, lb, ub; orthopolys = Uniform01OrthoPoly(1))
+            x, y, lb, ub; orthopolys = Uniform01OrthoPoly(1)
+        )
         @test my_pce_changed(x_val) ≈ f(x_val)
     end
 
@@ -412,7 +431,8 @@ end
         update!(my_svm_ND, [(1.0, 1.0)], [1.0])
         update!(my_svm_ND, [(1.2, 1.2), (1.5, 1.5)], [1.728, 3.375])
         svm = LIBSVM.fit!(
-            SVC(), transpose(reduce(hcat, collect.(my_svm_ND.x))), my_svm_ND.y)
+            SVC(), transpose(reduce(hcat, collect.(my_svm_ND.x))), my_svm_ND.y
+        )
         x_test = [1.0, 1.0]
         val = my_svm_ND(x_test)
         @test LIBSVM.predict(svm, reshape(x_test, 1, 2))[1] == val
@@ -439,14 +459,20 @@ end
         x = sample(50, lb, ub, SobolSample())
         y = discont_1D.(x)
 
-        # Radials vs MOE 
-        RAD_1D = RadialBasis(x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0,
-            sparse = false)
+        # Radials vs MOE
+        RAD_1D = RadialBasis(
+            x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0,
+            sparse = false
+        )
         expert_types = [
-            RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0,
-                sparse = false),
-            RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0,
-                sparse = false)
+            RadialBasisStructure(
+                radial_function = linearRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
+            RadialBasisStructure(
+                radial_function = cubicRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
         ]
 
         MOE_1D_RAD_RAD = MOE(x, y, expert_types)
@@ -457,8 +483,9 @@ end
 
         # Krig vs MOE
         KRIG_1D = Kriging(x, y, lb, ub, p = 1.0, theta = 1.0)
-        expert_types = [InverseDistanceStructure(p = 1.0),
-            KrigingStructure(p = 1.0, theta = 1.0)
+        expert_types = [
+            InverseDistanceStructure(p = 1.0),
+            KrigingStructure(p = 1.0, theta = 1.0),
         ]
         MOE_1D_INV_KRIG = MOE(x, y, expert_types)
         MOE_at0 = MOE_1D_INV_KRIG(0.0)
@@ -499,8 +526,10 @@ end
 
         expert_types = [
             KrigingStructure(p = [1.0, 1.0], theta = [1.0, 1.0]),
-            RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0,
-                sparse = false)
+            RadialBasisStructure(
+                radial_function = linearRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
         ]
         moe_nd_krig_rad = MOE(x, y, expert_types, ndim = 2, quantile = 5)
         moe_pred_vals = moe_nd_krig_rad.(x_test)
@@ -536,10 +565,12 @@ end
 
         # test if MOE handles 3 experts including SurrogatesFlux
         expert_types = [
-            RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0,
-                sparse = false),
+            RadialBasisStructure(
+                radial_function = linearRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
             LinearStructure(),
-            InverseDistanceStructure(p = 1.0)
+            InverseDistanceStructure(p = 1.0),
         ]
         moe_nd_3_experts = MOE(x, y, expert_types, ndim = 2, n_clusters = 3)
         moe_pred_vals = moe_nd_3_experts.(x_test)
@@ -551,7 +582,7 @@ end
         n_epochs = 1
         expert_types = [
             NeuralStructure(model = model, loss = loss, opt = opt, n_epochs = n_epochs),
-            LinearStructure()
+            LinearStructure(),
         ]
         moe_nn_ln = MOE(x, y, expert_types, ndim = 2)
         moe_pred_vals = moe_nn_ln.(x_test)
@@ -573,10 +604,14 @@ end
         y = discont_1D.(x)
 
         expert_types = [
-            RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0,
-                sparse = false),
-            RadialBasisStructure(radial_function = cubicRadial(), scale_factor = 1.0,
-                sparse = false)
+            RadialBasisStructure(
+                radial_function = linearRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
+            RadialBasisStructure(
+                radial_function = cubicRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
         ]
         moe = MOE(x, y, expert_types)
         Surrogates.update!(moe, 0.5, 5.0)
@@ -598,9 +633,12 @@ end
         n = 110
         x = sample(n, lb, ub, LatinHypercubeSample())
         y = discont_NDIM.(x)
-        expert_types = [InverseDistanceStructure(p = 1.0),
-            RadialBasisStructure(radial_function = linearRadial(), scale_factor = 1.0,
-                sparse = false)
+        expert_types = [
+            InverseDistanceStructure(p = 1.0),
+            RadialBasisStructure(
+                radial_function = linearRadial(), scale_factor = 1.0,
+                sparse = false
+            ),
         ]
         moe_nd_inv_rad = MOE(x, y, expert_types, ndim = 2)
         Surrogates.update!(moe_nd_inv_rad, (0.5, 0.5), sum((0.5, 0.5) .^ 2) + 5)

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -56,9 +56,11 @@ using Surrogates
 
     @testset "BigFloat Support - ND Surrogates" begin
         # Test data with BigFloat for N-dimensional
-        x_bf = [(BigFloat(1.0), BigFloat(2.0)), (BigFloat(2.0), BigFloat(3.0)),
+        x_bf = [
+            (BigFloat(1.0), BigFloat(2.0)), (BigFloat(2.0), BigFloat(3.0)),
             (BigFloat(3.0), BigFloat(1.0)), (BigFloat(4.0), BigFloat(4.0)),
-            (BigFloat(5.0), BigFloat(2.0))]
+            (BigFloat(5.0), BigFloat(2.0)),
+        ]
         y_bf = BigFloat[0.5, 1.2, 2.1, 2.8, 3.5]
         lb_bf = (BigFloat(0.0), BigFloat(0.0))
         ub_bf = (BigFloat(6.0), BigFloat(5.0))

--- a/test/lobachevsky.jl
+++ b/test/lobachevsky.jl
@@ -25,7 +25,7 @@ int = quadgk(obj, a, b)
 int_val_true = int[1] - int[2]
 @test abs(int_1D - int_val_true) < 2 * 10^-5
 update!(my_loba, 3.7, 12.1)
-update!(my_loba, [1.23, 3.45], [5.20, 109.67])
+update!(my_loba, [1.23, 3.45], [5.2, 109.67])
 
 #ND
 

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -14,38 +14,50 @@ using Test
     jet_kwargs = (; target_modules = (Surrogates,))
 
     @testset "LinearSurrogate" begin
-        rep = JET.report_call(LinearSurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            LinearSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "RadialBasis" begin
-        rep = JET.report_call(RadialBasis,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            RadialBasis,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "Kriging" begin
-        rep = JET.report_call(Kriging,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            Kriging,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "InverseDistanceSurrogate" begin
-        rep = JET.report_call(InverseDistanceSurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            InverseDistanceSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "SecondOrderPolynomialSurrogate" begin
-        rep = JET.report_call(SecondOrderPolynomialSurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            SecondOrderPolynomialSurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 
     @testset "LobachevskySurrogate" begin
-        rep = JET.report_call(LobachevskySurrogate,
-            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...)
+        rep = JET.report_call(
+            LobachevskySurrogate,
+            (typeof(x1d), typeof(y1d), Float64, Float64); jet_kwargs...
+        )
         @test isempty(JET.get_reports(rep))
     end
 end

--- a/test/optimization.jl
+++ b/test/optimization.jl
@@ -24,31 +24,41 @@ x = [2.5, 4.0, 6.0]
 y = [6.0, 9.0, 13.0]
 my_k_SRBF1 = Kriging(x, y, lb, ub; p)
 xstar,
-fstar = surrogate_optimize!(objective_function, SRBF(), a, b, my_k_SRBF1,
-    RandomSample())
+    fstar = surrogate_optimize!(
+    objective_function, SRBF(), a, b, my_k_SRBF1,
+    RandomSample()
+)
 
 #Using RadialBasis
 
 x = [2.5, 4.0, 6.0]
 y = [6.0, 9.0, 13.0]
 my_rad_SRBF1 = RadialBasis(x, y, a, b, rad = linearRadial())
-(xstar,
-    fstar) = surrogate_optimize!(objective_function, SRBF(), a, b, my_rad_SRBF1,
-    RandomSample())
+(
+    xstar,
+    fstar,
+) = surrogate_optimize!(
+    objective_function, SRBF(), a, b, my_rad_SRBF1,
+    RandomSample()
+)
 
 x = [2.5, 4.0, 6.0]
 y = [6.0, 9.0, 13.0]
 my_wend_1d = Wendland(x, y, lb, ub)
 xstar,
-fstar = surrogate_optimize!(objective_function, SRBF(), a, b, my_wend_1d,
-    RandomSample())
+    fstar = surrogate_optimize!(
+    objective_function, SRBF(), a, b, my_wend_1d,
+    RandomSample()
+)
 
 x = [2.5, 4.0, 6.0]
 y = [6.0, 9.0, 13.0]
 my_earth1d = EarthSurrogate(x, y, lb, ub)
 xstar,
-fstar = surrogate_optimize!(objective_function, SRBF(), a, b, my_earth1d,
-    HaltonSample())
+    fstar = surrogate_optimize!(
+    objective_function, SRBF(), a, b, my_earth1d,
+    HaltonSample()
+)
 
 ##### ND #####
 objective_function_ND = z -> 3 * norm(z) + 1
@@ -62,8 +72,10 @@ y = objective_function_ND.(x)
 my_k_SRBFN = Kriging(x, y, lb, ub)
 #Every optimization method now returns the y_min and its position
 x_min,
-y_min = surrogate_optimize!(objective_function_ND, SRBF(), lb, ub, my_k_SRBFN,
-    RandomSample())
+    y_min = surrogate_optimize!(
+    objective_function_ND, SRBF(), lb, ub, my_k_SRBFN,
+    RandomSample()
+)
 
 #Radials
 lb = [1.0, 1.0]
@@ -89,8 +101,10 @@ x = sample(500, lb, ub, SobolSample())
 objective_function_ND = z -> 3 * norm(z) + 1
 y = objective_function_ND.(x)
 my_linear_ND = LinearSurrogate(x, y, lb, ub)
-surrogate_optimize!(objective_function_ND, SRBF(), lb, ub, my_linear_ND, SobolSample(),
-    maxiters = 15)
+surrogate_optimize!(
+    objective_function_ND, SRBF(), lb, ub, my_linear_ND, SobolSample(),
+    maxiters = 15
+)
 
 #SVM
 lb = [1.0, 1.0]
@@ -100,7 +114,8 @@ objective_function_ND = z -> 3 * norm(z) + 1
 y = objective_function_ND.(x)
 my_SVM_ND = SVMSurrogate(x, y, lb, ub)
 surrogate_optimize!(
-    objective_function_ND, SRBF(), lb, ub, my_SVM_ND, SobolSample(), maxiters = 15)
+    objective_function_ND, SRBF(), lb, ub, my_SVM_ND, SobolSample(), maxiters = 15
+)
 
 #Inverse distance surrogate
 lb = [1.0, 1.0]
@@ -110,8 +125,10 @@ objective_function_ND = z -> 3 * norm(z) + 1
 my_p = 2.5
 y = objective_function_ND.(x)
 my_inverse_ND = InverseDistanceSurrogate(x, y, lb, ub, p = my_p)
-surrogate_optimize!(objective_function_ND, SRBF(), lb, ub, my_inverse_ND, SobolSample(),
-    maxiters = 15)
+surrogate_optimize!(
+    objective_function_ND, SRBF(), lb, ub, my_inverse_ND, SobolSample(),
+    maxiters = 15
+)
 
 #SecondOrderPolynomialSurrogate
 lb = [0.0, 0.0]
@@ -120,8 +137,10 @@ obj_ND = x -> log(x[1]) * exp(x[2])
 x = sample(15, lb, ub, RandomSample())
 y = obj_ND.(x)
 my_second_order_poly_ND = SecondOrderPolynomialSurrogate(x, y, lb, ub)
-surrogate_optimize!(obj_ND, SRBF(), lb, ub, my_second_order_poly_ND, SobolSample(),
-    maxiters = 15)
+surrogate_optimize!(
+    obj_ND, SRBF(), lb, ub, my_second_order_poly_ND, SobolSample(),
+    maxiters = 15
+)
 
 ####### LCBS #########
 ######1D######
@@ -152,7 +171,7 @@ surrogate_optimize!(objective_function_ND, LCBS(), lb, ub, my_k_LCBSN, RandomSam
 ##### EI ######
 
 ###1D###
-objective_function = x -> (x + 1)^2 - x + 2# Minimum of this function is at x = -0.5, y = -2.75
+objective_function = x -> (x + 1)^2 - x + 2 # Minimum of this function is at x = -0.5, y = -2.75
 true_min_x = -0.5
 true_min_y = objective_function(true_min_x)
 lb = -5
@@ -160,8 +179,10 @@ ub = 5
 x = sample(5, lb, ub, SobolSample())
 y = objective_function.(x)
 my_k_EI1 = Kriging(x, y, lb, ub; p = 2)
-surrogate_optimize!(objective_function, EI(), lb, ub, my_k_EI1, SobolSample(),
-    maxiters = 200, num_new_samples = 155)
+surrogate_optimize!(
+    objective_function, EI(), lb, ub, my_k_EI1, SobolSample(),
+    maxiters = 200, num_new_samples = 155
+)
 
 # Check that EI is correctly minimizing the objective
 y_min, index_min = findmin(my_k_EI1.y)
@@ -190,7 +211,7 @@ y_min, index_min = findmin(my_k_EIN.y)
 x_min = my_k_EIN.x[index_min]
 @test norm(x_min .- true_min_x) < 0.05 * norm(ub .- lb)
 @test abs(y_min - true_min_y) <
-      0.05 * (objective_function_ND(ub) - objective_function_ND(lb))
+    0.05 * (objective_function_ND(ub) - objective_function_ND(lb))
 
 ###ND with SectionSampler###
 # We will make sure the EI function finds the minimum when constrained to a specific slice of 3D space
@@ -217,7 +238,7 @@ y_min, index_min = findmin(my_k_EIN_section.y)
 x_min = my_k_EIN_section.x[index_min]
 @test norm(x_min .- true_min_x) < 0.05 * norm(ub .- lb)
 @test abs(y_min - true_min_y) <
-      0.05 * (objective_function_section(ub) - objective_function_section(lb))
+    0.05 * (objective_function_section(ub) - objective_function_section(lb))
 
 ## DYCORS ##
 
@@ -245,17 +266,22 @@ lb = [1.0, 1.0]
 ub = [6.0, 6.0]
 
 my_k_DYCORSN = Kriging(x, y, lb, ub)
-surrogate_optimize!(objective_function_ND, DYCORS(), lb, ub, my_k_DYCORSN, RandomSample(),
-    maxiters = 30)
+surrogate_optimize!(
+    objective_function_ND, DYCORS(), lb, ub, my_k_DYCORSN, RandomSample(),
+    maxiters = 30
+)
 
 my_rad_DYCORSN = RadialBasis(x, y, lb, ub, rad = linearRadial())
 surrogate_optimize!(
     objective_function_ND, DYCORS(), lb, ub, my_rad_DYCORSN, RandomSample(),
-    maxiters = 30)
+    maxiters = 30
+)
 
 my_wend_ND = Wendland(x, y, lb, ub)
-surrogate_optimize!(objective_function_ND, DYCORS(), lb, ub, my_wend_ND, RandomSample(),
-    maxiters = 30)
+surrogate_optimize!(
+    objective_function_ND, DYCORS(), lb, ub, my_wend_ND, RandomSample(),
+    maxiters = 30
+)
 
 ### SOP ###
 # 1D
@@ -267,8 +293,10 @@ lb = 1.0
 ub = 6.0
 num_centers = 2
 my_k_SOP1 = Kriging(x, y, lb, ub, p = 1.9)
-surrogate_optimize!(objective_function, SOP(num_centers), lb, ub, my_k_SOP1, SobolSample(),
-    maxiters = 60)
+surrogate_optimize!(
+    objective_function, SOP(num_centers), lb, ub, my_k_SOP1, SobolSample(),
+    maxiters = 60
+)
 #ND
 objective_function_ND = z -> 2 * norm(z) + 1
 x = [(2.3, 2.2), (1.4, 1.5)]
@@ -279,8 +307,10 @@ lb = [1.0, 1.0]
 ub = [6.0, 6.0]
 my_k_SOPND = Kriging(x, y, lb, ub)
 num_centers = 2
-surrogate_optimize!(objective_function_ND, SOP(num_centers), lb, ub, my_k_SOPND,
-    SobolSample(), maxiters = 20)
+surrogate_optimize!(
+    objective_function_ND, SOP(num_centers), lb, ub, my_k_SOPND,
+    SobolSample(), maxiters = 20
+)
 
 f = x -> [x^2, x]
 lb = 1.0
@@ -301,5 +331,7 @@ K = 2 #number of revaluations
 p_cross = 0.5 #crossing vs copy
 n_c = 1.0 # hyperparameter for children creation
 sigma = 1.5 # mutation
-surrogate_optimize!(f, RTEA(K, Z, p_cross, n_c, sigma), lb, ub,
-    my_radial_basis_rtea, SobolSample(); maxiters = 10)
+surrogate_optimize!(
+    f, RTEA(K, Z, p_cross, n_c, sigma), lb, ub,
+    my_radial_basis_rtea, SobolSample(); maxiters = 10
+)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -15,13 +15,15 @@ y = f.(x)
 
 my_k = Kriging(x, y, lb, ub)
 new_x,
-eis = potential_optimal_points(EI(),
+    eis = potential_optimal_points(
+    EI(),
     MeanConstantLiar(),
     lb,
     ub,
     my_k,
     SobolSample(),
-    3)
+    3
+)
 
 @test length(new_x) == 3
 @test length(eis) == 3
@@ -30,13 +32,15 @@ eis = potential_optimal_points(EI(),
 
 my_surr = RadialBasis(x, y, lb, ub)
 new_x,
-eis = potential_optimal_points(SRBF(),
+    eis = potential_optimal_points(
+    SRBF(),
     MeanConstantLiar(),
     lb,
     ub,
     my_surr,
     SobolSample(),
-    3)
+    3
+)
 @test length(new_x) == 3
 @test length(eis) == 3
 
@@ -51,13 +55,15 @@ y = f.(x)
 my_k = Kriging(x, y, lb, ub)
 
 new_x,
-eis = potential_optimal_points(EI(),
+    eis = potential_optimal_points(
+    EI(),
     MeanConstantLiar(),
     lb,
     ub,
     my_k,
     SobolSample(),
-    5)
+    5
+)
 
 @test length(new_x) == 5
 @test length(eis) == 5
@@ -68,25 +74,29 @@ eis = potential_optimal_points(EI(),
 
 my_surr = RadialBasis(x, y, lb, ub)
 new_x,
-eis = potential_optimal_points(SRBF(),
+    eis = potential_optimal_points(
+    SRBF(),
     MeanConstantLiar(),
     lb,
     ub,
     my_surr,
     SobolSample(),
-    5)
+    5
+)
 
 @test length(new_x) == 5
 @test length(eis) == 5
 
 @test length(new_x[1]) == 3
 
-# # Check hyperparameter validation for potential_optimal_points 
+# # Check hyperparameter validation for potential_optimal_points
 @test_throws ArgumentError new_x,
-eis=potential_optimal_points(EI(),
+    eis = potential_optimal_points(
+    EI(),
     MeanConstantLiar(),
     lb,
     ub,
     my_k,
     SobolSample(),
-    -1)
+    -1
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,58 +21,58 @@ if GROUP == "All" || GROUP == "Core"
             include("qa.jl")
         end
         @testset "Extensions" begin
-        include("extensions.jl")
-    end
-    @testset "Algorithms" begin
-        @time @safetestset "GEKPLS" begin
-            include("GEKPLS.jl")
+            include("extensions.jl")
         end
-        @time @safetestset "Radials" begin
-            include("Radials.jl")
+        @testset "Algorithms" begin
+            @time @safetestset "GEKPLS" begin
+                include("GEKPLS.jl")
+            end
+            @time @safetestset "Radials" begin
+                include("Radials.jl")
+            end
+            @time @safetestset "Kriging" begin
+                include("Kriging.jl")
+            end
+            @time @safetestset "Sampling" begin
+                include("sampling.jl")
+            end
+            @time @safetestset "Optimization" begin
+                include("optimization.jl")
+            end
+            @time @safetestset "LinearSurrogate" begin
+                include("linearSurrogate.jl")
+            end
+            @time @safetestset "Lobachevsky" begin
+                include("lobachevsky.jl")
+            end
+            @time @safetestset "InverseDistanceSurrogate" begin
+                include("inverseDistanceSurrogate.jl")
+            end
+            @time @safetestset "SecondOrderPolynomialSurrogate" begin
+                include("secondOrderPolynomialSurrogate.jl")
+            end
+            # @time @safetestset  "AD_Compatibility" begin include("AD_compatibility.jl") end
+            @time @safetestset "Wendland" begin
+                include("Wendland.jl")
+            end
+            @time @safetestset "VariableFidelity" begin
+                include("VariableFidelity.jl")
+            end
+            @time @safetestset "Earth" begin
+                include("earth.jl")
+            end
+            @time @safetestset "Gradient Enhanced Kriging" begin
+                include("GEK.jl")
+            end
+            @time @safetestset "Section Samplers" begin
+                include("SectionSampleTests.jl")
+            end
         end
-        @time @safetestset "Kriging" begin
-            include("Kriging.jl")
+        @time @safetestset "AD" begin
+            include("AD_compatibility.jl")
         end
-        @time @safetestset "Sampling" begin
-            include("sampling.jl")
+        @time @safetestset "Interface Compatibility" begin
+            include("interface_tests.jl")
         end
-        @time @safetestset "Optimization" begin
-            include("optimization.jl")
-        end
-        @time @safetestset "LinearSurrogate" begin
-            include("linearSurrogate.jl")
-        end
-        @time @safetestset "Lobachevsky" begin
-            include("lobachevsky.jl")
-        end
-        @time @safetestset "InverseDistanceSurrogate" begin
-            include("inverseDistanceSurrogate.jl")
-        end
-        @time @safetestset "SecondOrderPolynomialSurrogate" begin
-            include("secondOrderPolynomialSurrogate.jl")
-        end
-        # @time @safetestset  "AD_Compatibility" begin include("AD_compatibility.jl") end
-        @time @safetestset "Wendland" begin
-            include("Wendland.jl")
-        end
-        @time @safetestset "VariableFidelity" begin
-            include("VariableFidelity.jl")
-        end
-        @time @safetestset "Earth" begin
-            include("earth.jl")
-        end
-        @time @safetestset "Gradient Enhanced Kriging" begin
-            include("GEK.jl")
-        end
-        @time @safetestset "Section Samplers" begin
-            include("SectionSampleTests.jl")
-        end
-    end
-    @time @safetestset "AD" begin
-        include("AD_compatibility.jl")
-    end
-    @time @safetestset "Interface Compatibility" begin
-        include("interface_tests.jl")
-    end
     end
 end

--- a/test/secondOrderPolynomialSurrogate.jl
+++ b/test/secondOrderPolynomialSurrogate.jl
@@ -63,7 +63,7 @@ update!(surrogate, x_new, y_new)
 
 # surrogate should recover 2nd order polynomial
 function second_order_target(x; a = 0.3, b = [0.7, 0.1], c = [0.3 0.4; 0.4 0.1])
-    a + b' * x + x' * c * x
+    return a + b' * x + x' * c * x
 end
 second_order_target(x::Tuple; kwargs...) = f([x...]; kwargs...)
 lb = fill(-5.0, 2);


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)