### PR TITLE
Improve precompilation: Add GEK, EarthSurrogate, and std_error_at_point

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -13,6 +13,9 @@ using PrecompileTools
     lb_nd = (0.0, 0.0)
     ub_nd = (10.0, 10.0)
 
+    # GEK test data (1D) - includes gradients
+    y_gek_1d = vcat(y_1d, 2.0 .* x_1d)
+
     @compile_workload begin
         # RadialBasis - most used surrogate (1D)
         rad_1d = RadialBasis(x_1d, y_1d, lb_1d, ub_1d)
@@ -30,6 +33,7 @@ using PrecompileTools
         # Kriging - nD
         krig_nd = Kriging(x_nd, y_nd, lb_nd, ub_nd)
         krig_nd((2.5, 3.5))
+        std_error_at_point(krig_nd, (2.5, 3.5))
 
         # LinearSurrogate (1D)
         lin_1d = LinearSurrogate(x_1d, y_1d, lb_1d, ub_1d)
@@ -54,6 +58,19 @@ using PrecompileTools
         # Wendland (1D)
         wend_1d = Wendland(x_1d, y_1d, lb_1d, ub_1d)
         wend_1d(2.5)
+
+        # GEK - Gradient Enhanced Kriging (1D)
+        gek_1d = GEK(x_1d, y_gek_1d, lb_1d, ub_1d)
+        gek_1d(2.5)
+        std_error_at_point(gek_1d, 2.5)
+
+        # EarthSurrogate (1D)
+        earth_1d = EarthSurrogate(x_1d, y_1d, lb_1d, ub_1d)
+        earth_1d(2.5)
+
+        # EarthSurrogate (nD)
+        earth_nd = EarthSurrogate(x_nd, y_nd, lb_nd, ub_nd)
+        earth_nd((2.5, 3.5))
 
         # Sampling - Sobol
         sample(5, lb_1d, ub_1d, SobolSample())


### PR DESCRIPTION
## Summary

This PR improves precompilation coverage by adding workloads for surrogates that had significant time-to-first-execution (TTFX) delays:

- **GEK (Gradient Enhanced Kriging) 1D**: ~0.86s → ~0.0005s (1680x faster)
- **EarthSurrogate 1D and nD**: ~1.02s → ~0.012s (85x faster)
- **std_error_at_point for nD Kriging**: ~0.084s → ~0.00004s (2100x faster)

### Performance Measurements

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| GEK construction (1D) | 0.84s | 0.0005s | **1680x** |
| GEK prediction | 0.017s | 0.00002s | **850x** |
| std_error_at_point (nD) | 0.084s | 0.00004s | **2100x** |
| EarthSurrogate construction (1D) | 1.02s | 0.012s | **85x** |
| EarthSurrogate prediction | 0.063s | 0.00005s | **1260x** |
| **Total TTFX** | **~2.0s** | **~0.013s** | **154x** |

### Trade-offs

- Precompilation time: +2s (16s → 18s)
- Package load time: +0.35s (2.44s → 2.79s)

The TTFX improvement (154x) far outweighs the modest increase in load time.

### Analysis

- Zero invalidations originate from Surrogates.jl code (all 190 invalidations are from dependencies)
- The package was already well-optimized for common surrogates; this PR extends coverage to GEK and EarthSurrogate

## Test plan

- [x] All tests pass (319 passed, 2 broken - pre-existing)
- [x] Verified TTFX improvements with benchmarks
- [x] Confirmed no new invalidations introduced

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)