### PR TITLE
Fix downgrade test stalling by bumping Zygote compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -63,7 +63,7 @@ Statistics = "1.10"
 SurrogatesBase = "1.1.0"
 Test = "1.10"
 XGBoost = "2"
-Zygote = "0.7"
+Zygote = "0.7.3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

- Bumps Zygote compat from `0.7` to `0.7.3` to fix downgrade test stalling

## Problem

The downgrade tests were stalling for 6+ hours and getting cancelled. Investigation revealed that the issue was **Zygote v0.7.0**, which the downgrade test pins to as the minimum compatible version.

### Evidence

| Test Environment | Julia | Zygote | Result |
|-----------------|-------|--------|--------|
| LTS Normal | 1.10.10 | 0.7.10 | ✅ Completes in ~25 min |
| Downgrade | 1.10.10 | 0.7.0 | ❌ Hangs for 6+ hours |

The hang occurs during MOE tests in `AD_compatibility.jl` when creating GMM models with 900 data points. While the GMM constructor doesn't use Zygote directly, there's some problematic interaction in the v0.7.0 test environment that causes the EM algorithm to hang after K-means initialization.

### Root Cause Analysis

1. Both tests use the same Julia version (1.10.10) and GaussianMixtures version (0.3.13)
2. The only significant difference is the Zygote version (0.7.0 vs 0.7.10)
3. The hang happens during GMM creation, not during gradient computation
4. Something in Zygote v0.7.0's environment causes the issue

## Test plan

- [ ] Verify downgrade CI passes with the new Zygote compat bound
- [ ] Verify normal CI still passes

🤖 Generated with [Claude Code](https://claude.ai/code)