### PR TITLE
Vector-output GEKPLS via PLS2 + multi-output BLUP

### DIFF
--- a/src/GEKPLS.jl
+++ b/src/GEKPLS.jl
@@ -1,28 +1,44 @@
 """
-GEKPLS(x, y, x_matrix, y_matrix, grads, xlimits, delta_x, extra_points, n_comp, beta, gamma, theta,
-reduced_likelihood_function_value,
-X_offset, X_scale, X_after_std, pls_mean_reshaped, y_mean, y_std)
+    GEKPLS
+
+Gradient-Enhanced Kriging with Partial Least Squares surrogate model.
+
+Supports both scalar outputs (`y::Number`) and vector outputs
+(`y::AbstractVector{<:Real}` of length `ny`). For vector outputs the model uses
+a single set of hyperparameters and PLS rotations shared across all `ny`
+output dimensions (PLS2 in the local Taylor-augmented PLS step), and
+independent BLUP coefficients per output (`beta`, `gamma`, `sigma2`). See:
+
+  - Bouhlel & Martins, "Gradient-enhanced kriging for high-dimensional
+    problems", Engineering with Computers 35 (2019), arXiv:1708.02663.
+  - Wold, Sjöström & Eriksson, "PLS-regression: a basic tool of
+    chemometrics" (2001), for the NIPALS PLS2 algorithm.
+
+Fields below use the internal canonical shapes; `y_matrix` is `(nt, ny)`,
+`grads` is `(nt, dim, ny)` storing `∂y_k/∂x_j`, and `beta`/`gamma`/`y_mean`/
+`y_std` carry one column per output dimension.
 """
 mutable struct GEKPLS{T, X, Y} <: AbstractDeterministicSurrogate
     x::X
     y::Y
     x_matrix::Matrix{T} #1
-    y_matrix::Matrix{T} #2
-    grads::Matrix{T} #3
+    y_matrix::Matrix{T} #2 -- (nt, ny)
+    grads::Array{T, 3} #3 -- (nt, dim, ny); grads[i,j,k] = ∂y_k/∂x_j at x^(i)
     xl::Matrix{T} #xlimits #4
     delta::T #5
     extra_points::Int #6
     num_components::Int #7
-    beta::Vector{T} #8
-    gamma::Matrix{T} #9
+    beta::Matrix{T} #8 -- (1, ny)
+    gamma::Matrix{T} #9 -- (nt_after_PLS, ny)
     theta::Vector{T} #10
     reduced_likelihood_function_value::T #11
     X_offset::Matrix{T} #12
     X_scale::Matrix{T} #13
     X_after_std::Matrix{T} #14 - X after standardization
     pls_mean::Matrix{T} #15
-    y_mean::T #16
-    y_std::T #17
+    y_mean::Matrix{T} #16 -- (1, ny)
+    y_std::Matrix{T} #17 -- (1, ny)
+    scalar_output::Bool #18 -- if true, predict returns a scalar (legacy API)
 end
 
 """
@@ -44,25 +60,95 @@ function bounds_error(x, xl)
 end
 
 """
-    GEKPLS(X, y, grads, n_comp, delta_x, lb, ub, extra_points, theta)
+    _canonicalize_y_and_grads(y_vec, grads_vec, nt, dim)
 
-Constructor for GEKPLS Struct
+Convert the user-facing `(y_vec, grads_vec)` representation into the canonical
+internal storage `(y_matrix, grads_3tensor, scalar_output)`.
 
-  - x_vec: vector of tuples with x values
-  - y_vec: vector of floats with outputs
-  - grads_vec: gradients associated with each of the X points
-  - n_comp: number of components
-  - lb: lower bounds
-  - ub: upper bounds
-  - delta_x: step size while doing Taylor approximation
-  - extra_points: number of points to consider
-  - theta: initial expected variance of PLS regression components
+Scalar output (`eltype(y_vec) <: Number`):
+  - `y_matrix`: `(nt, 1)` matrix.
+  - `grads_3tensor`: `(nt, dim, 1)` array; populated via
+    [`vector_of_tuples_to_matrix2`](@ref) (Zygote-style gradient unpacking).
+  - `scalar_output = true`.
+
+Vector output (`eltype(y_vec) <: AbstractVector`):
+  - `y_matrix`: `(nt, ny)` matrix, one row per sample point.
+  - `grads_3tensor`: `(nt, dim, ny)` array. `grads_vec[i]` must be either a
+    `(ny, dim)` Jacobian matrix, or a 1-tuple wrapping one (e.g. as returned
+    by `Zygote.jacobian`), or any indexable object with `J[k, j] = ∂y_k/∂x_j`.
+  - `scalar_output = false`.
+"""
+function _canonicalize_y_and_grads(y_vec, grads_vec, nt, dim)
+    @assert length(y_vec) == nt "length(y_vec)=$(length(y_vec)) does not match length(x_vec)=$nt"
+    @assert length(grads_vec) == nt "length(grads_vec)=$(length(grads_vec)) does not match length(x_vec)=$nt"
+    if eltype(y_vec) <: Number
+        y_matrix = reshape(collect(float.(y_vec)), nt, 1)
+        grads_mat = vector_of_tuples_to_matrix2(grads_vec)
+        T = promote_type(eltype(y_matrix), eltype(grads_mat))
+        grads_3t = Array{T, 3}(undef, nt, dim, 1)
+        @inbounds for j in 1:dim, i in 1:nt
+            grads_3t[i, j, 1] = grads_mat[i, j]
+        end
+        return Matrix{T}(y_matrix), grads_3t, true
+    else
+        ny = length(first(y_vec))
+        T = promote_type(eltype(first(y_vec)), Float64)
+        y_matrix = Matrix{T}(undef, nt, ny)
+        @inbounds for i in 1:nt
+            yi = y_vec[i]
+            @assert length(yi) == ny "All entries of y_vec must have the same length (ny=$ny); entry $i has length $(length(yi))"
+            for k in 1:ny
+                y_matrix[i, k] = yi[k]
+            end
+        end
+        grads_3t = Array{T, 3}(undef, nt, dim, ny)
+        @inbounds for i in 1:nt
+            J = grads_vec[i]
+            if J isa Tuple
+                J = J[1]
+            end
+            @assert size(J, 1) == ny&&size(J, 2) == dim "grads_vec[$i] must be a (ny=$ny, dim=$dim) Jacobian; got size $(size(J))"
+            for k in 1:ny, j in 1:dim
+                grads_3t[i, j, k] = J[k, j]
+            end
+        end
+        return y_matrix, grads_3t, false
+    end
+end
+
+"""
+    GEKPLS(x_vec, y_vec, grads_vec, n_comp, delta_x, lb, ub, extra_points, theta)
+
+Construct a Gradient-Enhanced Kriging with Partial Least Squares surrogate.
+
+Arguments
+=========
+
+  - `x_vec`: vector of tuples giving the sampling locations in `R^dim`.
+  - `y_vec`: outputs at each sampling point. Either
+    * a `Vector{<:Number}` for scalar-valued targets (legacy API), or
+    * a `Vector{<:AbstractVector{<:Number}}` of length `nt`, with each entry a
+      length-`ny` vector, for vector-valued targets.
+  - `grads_vec`: derivatives at each sampling point. For scalar `y`, the
+    Zygote-style representation produced by `Zygote.gradient.(f, x_vec)` is
+    accepted. For vector `y`, each entry should be a `(ny, dim)` Jacobian
+    matrix (or a 1-tuple wrapping one, as returned by `Zygote.jacobian`).
+  - `n_comp`: number of PLS principal components retained.
+  - `delta_x`: step size for the first-order Taylor approximation around each
+    sample point.
+  - `lb`, `ub`: lower / upper bounds on the design space.
+  - `extra_points`: number of Taylor-extrapolated approximating points added
+    around each sample (in the most-influential PLS directions).
+  - `theta`: initial covariance hyperparameters (one per principal component).
+
+The surrogate `g` is then callable as `g(x)`, returning a scalar for the
+scalar-output case and a length-`ny` `Vector` for the vector-output case.
 """
 function GEKPLS(x_vec, y_vec, grads_vec, n_comp, delta_x, lb, ub, extra_points, theta)
     xlimits = hcat(lb, ub)
     X = vector_of_tuples_to_matrix(x_vec)
-    y = reshape(y_vec, (size(X, 1), 1))
-    grads = vector_of_tuples_to_matrix2(grads_vec)
+    nt, dim = size(X)
+    y, grads, scalar_output = _canonicalize_y_and_grads(y_vec, grads_vec, nt, dim)
 
     #ensure that X values are within the upper and lower bounds
     if bounds_error(X, xlimits)
@@ -83,19 +169,20 @@ function GEKPLS(x_vec, y_vec, grads_vec, n_comp, delta_x, lb, ub, extra_points, 
     D, ij = cross_distances(X_after_std)
     pls_mean_reshaped = reshape(pls_mean, (size(X, 2), n_comp))
     d = componentwise_distance_PLS(D, "squar_exp", n_comp, pls_mean_reshaped)
-    nt, nd = size(X_after_PLS)
+    nt_aug, _ = size(X_after_PLS)
     beta, gamma,
         reduced_likelihood_function_value = _reduced_likelihood_function(
         theta,
         "squar_exp",
-        d, nt, ij,
+        d, nt_aug, ij,
         y_after_std
     )
     return GEKPLS(
         x_vec, y_vec, X, y, grads, xlimits, delta_x, extra_points, n_comp, beta,
         gamma, theta,
         reduced_likelihood_function_value,
-        X_offset, X_scale, X_after_std, pls_mean_reshaped, y_mean, y_std
+        X_offset, X_scale, X_after_std, pls_mean_reshaped, y_mean, y_std,
+        scalar_output
     )
 end
 
@@ -109,32 +196,28 @@ function (g::GEKPLS)(x_vec::Number)
     _check_dimension(g, x_vec)
     # Convert scalar to tuple format for prep_data_for_pred
     x_vec_tuple = [(x_vec,)]
-    X_test = prep_data_for_pred(x_vec_tuple)
-    n_eval, n_features_x = size(X_test)
-    X_cont = (X_test .- g.X_offset) ./ g.X_scale
-    dx = differences(X_cont, g.X_after_std)
-    pred_d = componentwise_distance_PLS(dx, "squar_exp", g.num_components, g.pls_mean)
-    nt = size(g.X_after_std, 1)
-    r = transpose(reshape(squar_exp(g.theta, pred_d), (nt, n_eval)))
-    f = ones(n_eval, 1)
-    y_ = (f * g.beta) + (r * g.gamma)
-    y = g.y_mean .+ g.y_std * y_
-    return y[1]
+    return _gekpls_predict(g, x_vec_tuple)
 end
 
 function (g::GEKPLS)(x_vec)
     _check_dimension(g, x_vec)
+    return _gekpls_predict(g, x_vec)
+end
+
+function _gekpls_predict(g::GEKPLS, x_vec)
     X_test = prep_data_for_pred(x_vec)
-    n_eval, n_features_x = size(X_test)
+    n_eval, _ = size(X_test)
     X_cont = (X_test .- g.X_offset) ./ g.X_scale
     dx = differences(X_cont, g.X_after_std)
     pred_d = componentwise_distance_PLS(dx, "squar_exp", g.num_components, g.pls_mean)
     nt = size(g.X_after_std, 1)
     r = transpose(reshape(squar_exp(g.theta, pred_d), (nt, n_eval)))
     f = ones(n_eval, 1)
-    y_ = (f * g.beta) + (r * g.gamma)
-    y = g.y_mean .+ g.y_std * y_
-    return y[1]
+    y_ = (f * g.beta) + (r * g.gamma)           # (n_eval, ny)
+    y = g.y_mean .+ g.y_std .* y_               # (n_eval, ny)
+    # Single-point evaluation is the only API contract: return scalar or
+    # length-ny vector matching the user-facing `y_vec` shape.
+    return g.scalar_output ? y[1] : Vector(view(y, 1, :))
 end
 
 """
@@ -142,9 +225,10 @@ end
 
 add a new point to the dataset.
 """
-function SurrogatesBase.update!(g::GEKPLS, x_tup, y_val, grad_tup)
+function SurrogatesBase.update!(g::GEKPLS, x_tup, y_val, grad_val)
     new_x = prep_data_for_pred(x_tup)
-    new_grads = prep_data_for_pred(grad_tup)
+    dim = size(g.x_matrix, 2)
+    ny = size(g.y_matrix, 2)
     if vec(new_x) in eachrow(g.x_matrix)
         println("Adding a sample that already exists. Cannot build GEKPLS")
         return
@@ -154,13 +238,35 @@ function SurrogatesBase.update!(g::GEKPLS, x_tup, y_val, grad_tup)
         println("x values outside bounds")
         return
     end
+
+    new_y_row, new_grads_3t = if g.scalar_output
+        # legacy scalar API: y_val is a Number, grad_val is a tuple of tuples
+        new_grads_mat = prep_data_for_pred(grad_val)             # (1, dim)
+        (
+            reshape([float(y_val)], 1, 1),
+            reshape(new_grads_mat, 1, dim, 1),
+        )
+    else
+        # vector API: y_val is a length-ny vector,
+        # grad_val is a (ny, dim) Jacobian (or a 1-tuple wrapping one)
+        J = grad_val isa Tuple ? grad_val[1] : grad_val
+        @assert length(y_val) == ny "y_val must have length ny=$ny; got $(length(y_val))"
+        @assert size(J, 1) == ny&&size(J, 2) == dim "grad_val must be (ny=$ny, dim=$dim); got $(size(J))"
+        row = reshape(collect(float.(y_val)), 1, ny)
+        grads_block = Array{eltype(g.grads), 3}(undef, 1, dim, ny)
+        @inbounds for k in 1:ny, j in 1:dim
+            grads_block[1, j, k] = J[k, j]
+        end
+        (row, grads_block)
+    end
+
     temp_y = copy(g.y) #without the copy here, we get error ("cannot resize array with shared data")
     push!(g.x, x_tup)
     push!(temp_y, y_val)
     g.y = temp_y
     g.x_matrix = vcat(g.x_matrix, new_x)
-    g.y_matrix = vcat(g.y_matrix, y_val)
-    g.grads = vcat(g.grads, new_grads)
+    g.y_matrix = vcat(g.y_matrix, new_y_row)
+    g.grads = cat(g.grads, new_grads_3t, dims = 1)
     pls_mean, X_after_PLS,
         y_after_PLS = _ge_compute_pls(
         g.x_matrix, g.y_matrix,
@@ -176,7 +282,7 @@ function SurrogatesBase.update!(g::GEKPLS, x_tup, y_val, grad_tup)
     D, ij = cross_distances(g.X_after_std)
     g.pls_mean = reshape(pls_mean, (size(g.x_matrix, 2), g.num_components))
     d = componentwise_distance_PLS(D, "squar_exp", g.num_components, g.pls_mean)
-    nt, nd = size(X_after_PLS)
+    nt, _ = size(X_after_PLS)
     return g.beta, g.gamma,
         g.reduced_likelihood_function_value = _reduced_likelihood_function(
         g.theta,
@@ -215,10 +321,18 @@ function _ge_compute_pls(X, y, n_comp, grads, delta_x, xlimits, extra_points)
     # this function is equivalent to a combination of
     # https://github.com/SMTorg/smt/blob/f124c01ffa78c04b80221dded278a20123dac742/smt/utils/kriging_utils.py#L1036
     # and https://github.com/SMTorg/smt/blob/f124c01ffa78c04b80221dded278a20123dac742/smt/surrogate_models/gekpls.py#L48
+    #
+    # Multivariate-y extension: `y` is `(nt, ny)` and `grads` is `(nt, dim, ny)`
+    # with `grads[i,j,k] = ∂y_k/∂x_j` at `x^(i)`. The Taylor augmentation
+    # becomes `_y[bb, k] = y[i, k] + Σⱼ bb_dx[bb, j] * grads[i, j, k]`, i.e.
+    # `_y = y[i, :]ᵀ .+ bb_dx * grads[i, :, :]`. The PLS step is then PLS2 on
+    # the (n_bb, ny) response when ny>1, reducing exactly to PLS1 when ny==1
+    # (see `_get_first_singular_vectors_power_method`).
 
     nt, dim = size(X)
+    ny = size(y, 2)
     XX = zeros(0, dim)
-    yy = zeros(0, size(y)[2])
+    yy = zeros(0, ny)
     coeff_pls = zeros((dim, n_comp, nt))
 
     for i in 1:nt
@@ -243,25 +357,26 @@ function _ge_compute_pls(X, y, n_comp, grads, delta_x, xlimits, extra_points)
                 -1.0
             ] #left
         end
-        _X = zeros((size(bb_vals)[1], dim))
-        _y = zeros((size(bb_vals)[1], 1))
-        bb_vals = bb_vals .* (delta_x * (xlimits[:, 2] - xlimits[:, 1]))' #smt calls this sign. I've called it bb_vals
-        _X = X[i, :]' .+ bb_vals
-        bb_vals = bb_vals .* grads[i, :]'
-        _y = y[i, :] .+ sum(bb_vals, dims = 2)
-
-        #_pls.fit(_X, _y) # relic from sklearn version; retained for future reference.
-        #coeff_pls[:, :, i] = _pls.x_rotations_ #relic from sklearn version; retained for future reference.
+        # bb_dx: scaled perturbation vectors, size (n_bb, dim)
+        bb_dx = bb_vals .* (delta_x * (xlimits[:, 2] - xlimits[:, 1]))'
+        _X = X[i, :]' .+ bb_dx
+        # Multivariate FOTA: directional derivative for every output column.
+        # grads[i, :, :] is the (dim, ny) transposed Jacobian at sample i.
+        _y = reshape(y[i, :], 1, ny) .+ bb_dx * grads[i, :, :]   # (n_bb, ny)
 
         coeff_pls[:, :, i] = _modified_pls(_X, _y, n_comp) #_modified_pls returns the equivalent of SKLearn's _pls.x_rotations_
         if extra_points != 0
             start_index = max(1, length(coeff_pls[:, 1, i]) - extra_points + 1)
             max_coeff = sortperm(broadcast(abs, coeff_pls[:, 1, i]))[start_index:end]
             for ii in max_coeff
-                XX = [XX; transpose(X[i, :])]
-                XX[end, ii] += delta_x * (xlimits[ii, 2] - xlimits[ii, 1])
-                yy = [yy; y[i]]
-                yy[end] += grads[i, ii] * delta_x * (xlimits[ii, 2] - xlimits[ii, 1])
+                dx_ii = delta_x * (xlimits[ii, 2] - xlimits[ii, 1])
+                new_X_row = transpose(X[i, :])
+                new_X_row = copy(new_X_row)
+                new_X_row[1, ii] += dx_ii
+                XX = vcat(XX, new_X_row)
+                # FOTA per output: y(x + dx_ii e_ii)_k = y(x)_k + grads[i,ii,k]*dx_ii
+                new_y_row = reshape(y[i, :] .+ grads[i, ii, :] .* dx_ii, 1, ny)
+                yy = vcat(yy, new_y_row)
             end
         end
     end
@@ -386,9 +501,10 @@ function standardization(X, y)
     X_offset = mean(X, dims = 1)
     X_scale = std(X, dims = 1)
     X_scale = map(x -> (x == 0.0) ? x = 1 : x = x, X_scale) #to prevent division by 0 below
-    y_mean = mean(y)
-    y_std = std(y)
-    y_std = map(y -> (y == 0) ? y = 1 : y = y, y_std) #to prevent division by 0 below
+    # Per-output standardization so vector-valued y is normalized columnwise.
+    y_mean = mean(y, dims = 1)
+    y_std = std(y, dims = 1)
+    y_std = map(s -> (s == 0) ? one(s) : s, y_std) #to prevent division by 0 below
     X = (X .- X_offset) ./ X_scale
     y = (y .- y_mean) ./ y_std
     return X, y, X_offset, y_mean, X_scale, y_std
@@ -555,6 +671,15 @@ reduced_likelihood_function_value: real
 """
 function _reduced_likelihood_function(theta, kernel_type, d, nt, ij, y_norma, noise = 0.0)
     #equivalent of https://github.com/SMTorg/smt/blob/4a4df255b9259965439120091007f9852f41523e/smt/surrogate_models/krg_based.py#L247
+    #
+    # Multi-output extension: `y_norma` may be `(nt, ny)`. Under shared
+    # hyperparameters θ the kriging correlation matrix R, its Cholesky C, and
+    # the regression matrices F=1, Ft, Q, G are independent of the output
+    # index, so they are computed once. The BLUP coefficients then take one
+    # column per output: β is (1, ny), γ is (nt, ny), σ² is (1, ny). The
+    # objective preserves SMT's `-nt*log10(sum(σ²)) - nt*log10(detR)` form,
+    # where `sum(σ²)` now sums across the ny output dimensions — monotonically
+    # consistent with the standard concentrated log-likelihood for shared θ.
     reduced_likelihood_function_value = -Inf
     nugget = 1000000.0 * eps() #a jitter for numerical stability; reducing the multiple from 1000000.0 results in positive definite error for Cholesky decomposition;
     if kernel_type == "squar_exp" #todo - add other kernel type abs_exp etc.
@@ -572,12 +697,12 @@ function _reduced_likelihood_function(theta, kernel_type, d, nt, ij, y_norma, no
     Ft = C \ F
     Q, G = qr(Ft)
     Q = Array(Q)
-    Yt = C \ y_norma
+    Yt = C \ y_norma                              # (nt, ny)
     #todo - in smt, they check if the matrix is ill-conditioned using SVD. Verify and include if necessary
-    beta = G \ [(transpose(Q) ⋅ Yt)]
-    rho = Yt .- (Ft .* beta)
-    gamma = transpose(C) \ rho
-    sigma2 = sum((rho) .^ 2, dims = 1) / nt
+    beta = G \ (transpose(Q) * Yt)                # (1, ny)
+    rho = Yt .- (Ft * beta)                       # (nt, ny)
+    gamma = transpose(C) \ rho                    # (nt, ny)
+    sigma2 = sum(rho .^ 2, dims = 1) / nt         # (1, ny)
     detR = prod(diag(C) .^ (2.0 / nt))
     reduced_likelihood_function_value = -nt * log10(sum(sigma2)) - nt * log10(detR)
     return beta, gamma, reduced_likelihood_function_value
@@ -612,15 +737,44 @@ function _svd_flip_1d(u, v)
     return v .*= sign_
 end
 
-function _get_first_singular_vectors_power_method(X, Y)
+function _get_first_singular_vectors_power_method(X, Y; tol = 1.0e-6, max_iter = 500)
+    # NIPALS power iteration for the leading PLS components of (X, Y).
+    #
+    # When Y has a single column (PLS1, scalar response) one iteration is
+    # exact, and we reproduce the original implementation bit-for-bit so the
+    # scalar surrogate is unchanged.
+    # When Y has multiple columns (PLS2, vector response) we iterate the same
+    # body to convergence, following Wold's NIPALS algorithm; the initial
+    # `y_score` is the column of Y with the largest variance, matching
+    # scikit-learn's PLSRegression default.
     my_eps = eps()
-    y_score = vec(Y)
-    x_weights = transpose(X)y_score / dot(y_score, y_score)
+    ny = size(Y, 2)
+    if ny == 1
+        y_score = vec(Y)
+    else
+        vars = vec(var(Y, dims = 1))
+        y_score = Vector(view(Y, :, argmax(vars)))
+    end
+    x_weights = transpose(X) * y_score / dot(y_score, y_score)
     x_weights ./= (sqrt(dot(x_weights, x_weights)) + my_eps)
     x_score = X * x_weights
-    y_weights = transpose(Y)x_score / dot(x_score, x_score)
+    y_weights = transpose(Y) * x_score / dot(x_score, x_score)
     y_score = Y * y_weights / (dot(y_weights, y_weights) + my_eps)
-    #Equivalent in intent to https://github.com/scikit-learn/scikit-learn/blob/80598905e517759b4696c74ecc35c6e2eb508cff/sklearn/cross_decomposition/_pls.py#L66
+    if ny > 1
+        y_score_prev = similar(y_score)
+        for _ in 2:max_iter
+            y_score_prev .= y_score
+            x_weights = transpose(X) * y_score / (dot(y_score, y_score) + my_eps)
+            x_weights ./= (sqrt(dot(x_weights, x_weights)) + my_eps)
+            x_score = X * x_weights
+            y_weights = transpose(Y) * x_score / (dot(x_score, x_score) + my_eps)
+            y_score = Y * y_weights / (dot(y_weights, y_weights) + my_eps)
+            ref = max(norm(y_score), one(eltype(y_score)))
+            if norm(y_score - y_score_prev) < tol * ref
+                break
+            end
+        end
+    end
     if any(isnan.(x_weights)) || any(isnan.(y_weights))
         return false, false
     end

--- a/test/GEKPLS.jl
+++ b/test/GEKPLS.jl
@@ -1,5 +1,6 @@
 using Surrogates
 using Zygote
+using Statistics: mean, std
 
 # #water flow function tests
 function water_flow(x)
@@ -243,4 +244,140 @@ end
         sum_of_rmse += sqrt((sum((grads_surr_vec[i][1] .- grads[i][1]) .^ 2) / 3.0))
     end
     @test isapprox(sum_of_rmse, 0.05, atol = 0.01)
+end
+
+# Vector-output GEKPLS: a function f : R^d -> R^ny is approximated with the
+# full Taylor-augmented PLS2 + multi-output BLUP path.
+
+function _jacobian_at(f, xi, ny, d)
+    J = Matrix{Float64}(undef, ny, d)
+    for k in 1:ny
+        gtup = Zygote.gradient(z -> f(z)[k], xi)[1]
+        for j in 1:d
+            J[k, j] = gtup[j]
+        end
+    end
+    return J
+end
+
+# 6D vector-valued test problem with three correlated polynomial outputs.
+# Polynomial because the existing tests pass a fixed (un-optimized) θ; this
+# isolates the shared-θ multi-output kriging path from any goodness-of-fit
+# pathology of the chosen θ on hard non-polynomial responses.
+function multioutput_func(x)
+    a = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2 + x[5]^2 + x[6]^2
+    b = x[1] + 2 * x[2] + 3 * x[3] + 4 * x[4] + 5 * x[5] + 6 * x[6]
+    c = x[1] * (x[1] - 1) + x[2] * (x[2] - 1) + x[3] * (x[3] - 1) +
+        x[4] * (x[4] - 1) + x[5] * (x[5] - 1) + x[6] * (x[6] - 1)
+    return [a, b, c]
+end
+
+@testset "Test 12: Vector-output GEKPLS matches per-output scalar fits (6D, ny=3)" begin
+    lb = fill(-3.0, 6)
+    ub = fill(3.0, 6)
+    n = 80
+    x = sample(n, lb, ub, SobolSample())
+    y_vec = multioutput_func.(x)
+    jacs = [_jacobian_at(multioutput_func, xi, 3, 6) for xi in x]
+
+    n_comp = 3
+    delta_x = 0.0001
+    extra_points = 2
+    initial_theta = [0.01 for _ in 1:n_comp]
+
+    g_vec = GEKPLS(
+        x, y_vec, jacs, n_comp, delta_x, lb, ub, extra_points, initial_theta
+    )
+
+    n_test = 50
+    x_test = sample(n_test, lb, ub, GoldenSample())
+    y_true_mat = reduce(hcat, multioutput_func.(x_test))   # (3, n_test)
+    y_pred_mat = reduce(hcat, g_vec.(x_test))              # (3, n_test)
+
+    # Vector-output prediction is a length-ny vector, not a scalar.
+    @test g_vec.(x_test) isa Vector{<:AbstractVector}
+    @test length(g_vec(x_test[1])) == 3
+
+    # Per-output relative RMSE must be small in absolute terms. The
+    # shared-θ multi-output BLUP can be modestly worse than the per-output
+    # scalar fit because PLS2 averages information across the ny responses
+    # into a single rotation, but on smooth polynomial responses every
+    # output should still be predicted to within a few percent of its scale.
+    for k in 1:3
+        rmse_k = sqrt(mean((y_pred_mat[k, :] .- y_true_mat[k, :]) .^ 2))
+        scale_k = max(std(y_true_mat[k, :]), 1.0e-12)
+        @test rmse_k / scale_k < 0.05
+    end
+end
+
+@testset "Test 13: Vector wrapper with ny=1 matches legacy scalar surrogate" begin
+    # With ny=1 packaged as a length-1 vector, the multi-output path must
+    # reproduce the legacy scalar GEKPLS up to floating-point reordering
+    # in the Matrix-based BLUP solve.
+    lb = [-3.0, -3.0, -3.0]
+    ub = [3.0, 3.0, 3.0]
+    n = 60
+    x = sample(n, lb, ub, SobolSample())
+    y_scalar = sphere_function.(x)
+    grads_scalar = gradient.(sphere_function, x)
+
+    y_vec1 = [[yi] for yi in y_scalar]
+    jacs1 = [reshape(Float64[gi[1]...], 1, 3) for gi in grads_scalar]
+
+    n_comp = 2
+    delta_x = 0.0001
+    extra_points = 2
+    initial_theta = [0.01, 0.01]
+
+    g_scalar = GEKPLS(
+        x, y_scalar, grads_scalar, n_comp, delta_x, lb, ub, extra_points, initial_theta
+    )
+    g_vec = GEKPLS(
+        x, y_vec1, jacs1, n_comp, delta_x, lb, ub, extra_points, initial_theta
+    )
+
+    n_test = 30
+    x_test = sample(n_test, lb, ub, GoldenSample())
+    for xt in x_test
+        @test only(g_vec(xt)) ≈ g_scalar(xt) rtol = 1.0e-10
+    end
+end
+
+@testset "Test 14: Vector-output update! (3D, ny=2)" begin
+    f2(x) = [x[1]^2 + x[2]^2 + x[3]^2, sin(x[1]) + sin(x[2]) + sin(x[3])]
+    lb = [-2.0, -2.0, -2.0]
+    ub = [2.0, 2.0, 2.0]
+    n_comp = 2
+    delta_x = 0.0001
+    extra_points = 2
+    initial_theta = [0.01, 0.01]
+
+    x_init = [(1.0, 0.5, -0.5), (-1.0, 0.0, 1.0), (0.0, 1.0, -1.0)]
+    y_init = f2.(x_init)
+    jacs_init = [_jacobian_at(f2, xi, 2, 3) for xi in x_init]
+
+    g = GEKPLS(
+        x_init, y_init, jacs_init, n_comp, delta_x, lb, ub, extra_points, initial_theta
+    )
+
+    n_test = 50
+    x_test = sample(n_test, lb, ub, GoldenSample())
+    rmse_before = [
+        sqrt(mean([(g(xt)[k] - f2(xt)[k])^2 for xt in x_test])) for k in 1:2
+    ]
+
+    n_extra = 60
+    x_extra = sample(n_extra, lb, ub, SobolSample())
+    y_extra = f2.(x_extra)
+    jacs_extra = [_jacobian_at(f2, xi, 2, 3) for xi in x_extra]
+    for i in 1:n_extra
+        update!(g, x_extra[i], y_extra[i], jacs_extra[i])
+    end
+
+    rmse_after = [
+        sqrt(mean([(g(xt)[k] - f2(xt)[k])^2 for xt in x_test])) for k in 1:2
+    ]
+    for k in 1:2
+        @test rmse_after[k] < rmse_before[k]
+    end
 end


### PR DESCRIPTION
> [!NOTE]
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## Summary

`GEKPLS` previously assumed a scalar response: `y_matrix` was hardcoded to `(nt, 1)`, gradients to `(nt, dim)`, and the kriging BLUP collapsed to a single output via `transpose(Q) ⋅ Yt`. This PR generalizes the model to vector-valued targets `f : R^dim -> R^ny` while keeping the legacy scalar API bit-for-bit unchanged.

Motivated by a Discourse thread asking for derivative-informed surrogates that handle vector responses: https://discourse.julialang.org/t/surrogate-with-derivatives/137277/5

## Math

**Taylor augmentation** (`_ge_compute_pls`) — the local FOTA response is now a `(n_bb, ny)` matrix:

  _y[bb, k] = y[i, k] + Σⱼ bb_dx[bb, j] · ∂y_k/∂x_j

**PLS step** (`_get_first_singular_vectors_power_method`) — the scalar response case (PLS1) is exact after one power iteration; that path is preserved bit-for-bit. For vector response (PLS2) the same body is iterated to convergence following Wold's NIPALS algorithm. Initial `y_score` is the column of Y with the largest variance, matching scikit-learn's `PLSRegression` default.

**Multi-output BLUP** (`_reduced_likelihood_function`) — under shared θ across outputs the kriging correlation matrix R and its Cholesky factor are shared; β `(1, ny)` and γ `(nt, ny)` are then obtained from a single multi-RHS solve. The previous `transpose(Q) ⋅ Yt` (dot product, scalar) becomes `transpose(Q) * Yt` (matrix product).

References:
- Bouhlel & Martins, *Gradient-enhanced kriging for high-dimensional problems*, Engineering with Computers 35 (2019), [arXiv:1708.02663](https://arxiv.org/abs/1708.02663).
- Wold, Sjöström & Eriksson, *PLS-regression: a basic tool of chemometrics*, Chemometrics and Intelligent Laboratory Systems 58 (2001).

## API

The constructor auto-detects shape from `eltype(y_vec)`:
- `Vector{<:Number}` — legacy scalar API, unchanged.
- `Vector{<:AbstractVector{<:Number}}` — vector output; `grads_vec` entries must be `(ny, dim)` Jacobian matrices (or 1-tuples wrapping them, matching `Zygote.jacobian` output).

`g(x)` returns a scalar for scalar y and a length-`ny` `Vector` for vector y. `update!` mirrors the same auto-detection.

## Internal representation

- `y_matrix::Matrix{T}` (nt, ny)
- `grads::Array{T,3}` (nt, dim, ny) — stores `∂y_k/∂x_j`
- `beta::Matrix{T}`, `gamma::Matrix{T}`, `y_mean::Matrix{T}`, `y_std::Matrix{T}` — one column per output
- new `scalar_output::Bool` flag so predict returns the same type the user supplied

## Tests

- Existing 11 GEKPLS regression tests pass unchanged (bit-for-bit on the PLS1 path; per-output BLUP results match modulo float reordering).
- **Test 12** — vector-output fit on a 6D 3-output polynomial problem: each output's relative RMSE < 5%.
- **Test 13** — packaging a scalar response as a length-1 vector via the new path reproduces the legacy scalar surrogate to rtol=1e-10 over 30 test points.
- **Test 14** — `update!` on a vector-output model strictly improves per-output RMSE after additional samples.

Also verified locally that the Radials and Kriging algorithm test suites pass (unrelated, sanity check).

## Test plan

- [x] `Pkg.test` GEKPLS — 49 tests pass
- [x] Radials sanity — 30 tests pass
- [x] Kriging sanity — 26 tests pass
- [x] Runic formatting applied
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)