### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -9,26 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; 
-                                      Pkg.develop(PackageSpec(path=pwd()));
-                                      Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,ext
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage-directories: "src,ext"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,8 @@ on:
 jobs:
   test:
     if: false  # Disabled due to stalling - see issue #545
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.26.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI jobs to the centralized SciML reusable workflows (all pinned `@v1`, every caller gets `secrets: "inherit"`), matching the Sundials.jl end-state.

## Converted (inline -> central caller)
- **Documentation.yml** -> `documentation.yml@v1` (preserves `coverage-directories: src,ext`; coverage/codecov now handled centrally).
- **FormatCheck.yml** (Runic) -> `runic.yml@v1` (was `fredrikekre/runic-action` inline).
- **SpellCheck.yml** -> `spellcheck.yml@v1` (was `crate-ci/typos` inline).
- **Downgrade.yml** -> `downgrade.yml@v1` (preserves `julia-version: 1.10`, `skip: Pkg,TOML`, and the existing `if: false` disable from issue #545).

## Already central (unchanged)
- **Tests.yml** already calls `tests.yml@v1` with the full `version × group` matrix and `secrets: "inherit"`.

## Added
- None. No Downstream/Benchmark/CompatHelper workflows exist; Downgrade already present so not re-added.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` version-ignore (spellcheck is now centralized); dropped `/test` from the julia ecosystem block (no `test/Project.toml` exists); kept `/` and `/docs`. github-actions block kept (`directory: "/"`, weekly).

## Formatting / spelling
- Runic: ran `Runic.main(["--inplace","."])` locally — **no changes** (repo already Runic-clean from the inline check).
- Typos: `typos .` exits 0 — **0 fixes needed** (existing `.typos.toml` retained).

## Heads-up
- **Check names change.** The job/check names produced by the reusable workflows differ from the old inline ones, so branch-protection required-status-checks will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)