### PR TITLE
Raise Zygote compat floor to 0.7.8 (fix Downgrade CI hang/error)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.5.0"
+version = "7.5.1"
 authors = ["SciML"]
 
 [deps]
@@ -63,7 +63,7 @@ Statistics = "1.10"
 SurrogatesBase = "1.1.0"
 Test = "1.10"
 XGBoost = "2.4.1"
-Zygote = "0.7"
+Zygote = "0.7.8"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The **Downgrade / Downgrade Tests** lane on `master` has been red: it runs to the 6-hour GitHub job cap and is cancelled (e.g. run 27995917370 on #562, runner `self-hosted-4vcpu-8gb-smcsd`; run 27516102458, runner `demeter4-16`). The non-downgrade `Tests` lane (current deps) is green, so this is specific to the downgraded (min-compat) manifest.

The downgrade workflow pins each dep to its compat floor. With `Zygote = "0.7"` the floor is 0.7.0, and the test step hangs forever inside `test/AD_compatibility.jl`'s Zygote section (the job log shows the ForwardDiff GENN trainings finish, then total silence for 5.5h until the 6h cancel).

## Root cause (two stale-floor bugs, both upstream-fixed)

Reproduced locally on the real downgrade resolution (Julia 1.10, deps pinned to their compat floors), bisecting Zygote 0.7.0 … 0.7.11:

1. **RadialBasis gradient freezes compilation** on Zygote **0.7.0–0.7.3**. `Zygote.gradient(::RadialBasis, x)` never returns (killed at 240s; works in ~10s on 0.7.4). The accumulation loop in `_approx_rbf` produces nested thunks that explode the type and blow the stack — fixed upstream in **Zygote 0.7.4** ("Prevent nested thunks during accumulation").

2. **Kriging gradient throws** on Zygote **0.7.0–0.7.7**:
   ```
   MethodError: no method matching +(::NamedTuple{...}, ::Base.RefValue{Any})  # in Zygote.accum
   ```
   Fixed upstream in **Zygote 0.7.8** (FluxML/Zygote.jl#1574, "Accumulate mutable structs with `Ref`").

`0.7.8` is the minimal Zygote that makes both work.

## Fix

Raise the compat floor: `Zygote = "0.7"` → `Zygote = "0.7.8"` (patch version bump 7.5.0 → 7.5.1). No source/test changes.

## Verification (local, Julia 1.10, real downgrade manifest, Zygote pinned to the new floor 0.7.8)

- Downgrade resolves to exactly `Zygote v0.7.8` (resolution succeeds).
- `Zygote`/1D gradients: **7/7 pass** (Radials, Kriging, Linear, InverseDistance, Lobachevsky, SecondOrderPolynomial, Wendland) — `Test Summary: Zygote 1D | 7 7`.
- `Zygote`/ND gradients (tuple inputs as the suite uses): Radials, Kriging, Linear, InverseDistance all pass, with gradient values **identical** to Zygote 0.7.11 (the version the already-green non-downgrade `Tests` lane runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)