### PR TITLE
Bump version to 7.5.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.5.1"
+version = "7.5.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (7.5.1 -> 7.5.2) to release unreleased commits on `master` via JuliaRegistrator.