### PR TITLE
Expand SciMLTesting v2 compat

### DIFF
--- a/docs/src/InverseDistance.md
+++ b/docs/src/InverseDistance.md
@@ -2,6 +2,10 @@
 
 The **Inverse Distance Surrogate** is an interpolating method, and in this method, the unknown points are calculated with a weighted average of the sampling points. This model uses the inverse distance between the unknown and training points to predict the unknown point. We do not need to fit this model because the response of an unknown point x is computed with respect to the distance between x and the training points.
 
+```@docs
+InverseDistanceSurrogate
+```
+
 Let's optimize the following function to use Inverse Distance Surrogate:
 
 $f(x) = sin(x) + sin(x)^2 + sin(x)^3$.

--- a/docs/src/abstractgps.md
+++ b/docs/src/abstractgps.md
@@ -2,6 +2,11 @@
 
 Gaussian Process regression in Surrogates.jl is implemented as a simple wrapper around the [AbstractGPs.jl](https://github.com/JuliaGaussianProcesses/AbstractGPs.jl) package. AbstractGPs comes with a variety of covariance functions (kernels). See [KernelFunctions.jl](https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/) for examples.
 
+```@docs
+AbstractGPSurrogate
+logpdf_surrogate
+```
+
 !!! tip
     
     The examples below demonstrate the use of AbstractGPs with out-of-the-box settings without hyperparameter optimization (i.e. without changing parameters like lengthscale, signal variance, and noise variance). Beyond hyperparameter optimization, careful initialization of hyperparameters and priors on the parameters is required for this surrogate to work properly. For more details on how to fit GPs in practice, check out [A Practical Guide to Gaussian Processes](https://infallible-thompson-49de36.netlify.app/).

--- a/docs/src/gek.md
+++ b/docs/src/gek.md
@@ -2,6 +2,10 @@
 
 Gradient-enhanced Kriging is an extension of kriging which supports gradient information. GEK is usually more accurate than kriging. However, it is not computationally efficient when the number of inputs, the number of sampling points, or both, are high. This is mainly due to the size of the corresponding correlation matrix, which increases proportionally with both the number of inputs and the number of sampling points.
 
+```@docs
+GEK
+```
+
 Let's have a look at the following function to use Gradient Enhanced Surrogate:
 ``f(x) = x^3 - 6x^2 + 4x + 12``
 

--- a/docs/src/gekpls.md
+++ b/docs/src/gekpls.md
@@ -2,6 +2,10 @@
 
 Gradient Enhanced Kriging with Partial Least Squares Method (GEKPLS) is a surrogate modeling technique that brings down computation time and returns improved accuracy for high-dimensional problems. The Julia implementation of GEKPLS is adapted from the Python version by [SMT](https://github.com/SMTorg) which is based on this [paper](https://arxiv.org/pdf/1708.02663.pdf).
 
+```@docs
+GEKPLS
+```
+
 The following are the inputs when building a GEKPLS surrogate:
 
  1. x - The vector containing the training points

--- a/docs/src/lobachevsky.md
+++ b/docs/src/lobachevsky.md
@@ -2,6 +2,10 @@
 
 Lobachevsky splines function is a function that is used for univariate and multivariate scattered interpolation. Introduced by Lobachevsky in 1842 to investigate errors in astronomical measurements.
 
+```@docs
+lobachevsky_integrate_dimension
+```
+
 We are going to use a Lobachevsky surrogate to optimize $f(x)=sin(x)+sin(10/3 * x)$.
 
 First of all import `Surrogates` and `Plots`.

--- a/docs/src/moe.md
+++ b/docs/src/moe.md
@@ -2,6 +2,10 @@
 
 The Mixture of Experts (MOE) Surrogate model represents the interpolating function as a combination of other surrogate models. SurrogatesMOE is a Julia implementation of the Python version from the [SMT project](https://github.com/SMTorg/smt).
 
+```@docs
+MOE
+```
+
 MOE is most useful when we have a discontinuous function. For example, let's say we want to build a surrogate for the following function:
 
 ## 1D Example

--- a/docs/src/neural.md
+++ b/docs/src/neural.md
@@ -3,6 +3,12 @@
 It's possible to define a neural network as a surrogate, using Flux.
 This is useful because we can call optimization methods on it.
 
+```@docs
+NeuralSurrogate
+GENNSurrogate
+predict_derivative
+```
+
 First of all we will define the `Schaffer` function we are going to build a surrogate for.
 
 ```@example Neural_surrogate

--- a/docs/src/optimizations.md
+++ b/docs/src/optimizations.md
@@ -1,5 +1,15 @@
 # Optimization techniques
 
+```@docs
+SRBF
+LCBS
+EI
+DYCORS
+SOP
+SMB
+RTEA
+```
+
   - SRBF
 
 ```@docs

--- a/docs/src/parallel.md
+++ b/docs/src/parallel.md
@@ -2,6 +2,16 @@
 
 There are some situations where it can be beneficial to run multiple optimizations in parallel. For example, if your objective function is very expensive to evaluate, you may want to run multiple evaluations in parallel.
 
+```@docs
+potential_optimal_points
+MinimumConstantLiar
+MeanConstantLiar
+MaximumConstantLiar
+KrigingBeliever
+KrigingBelieverUpperBound
+KrigingBelieverLowerBound
+```
+
 ## Ask-Tell Interface
 
 To enable parallel optimization, we make use of an Ask-Tell interface. The user will construct the initial surrogate model the same way as for non-parallel surrogate models, but instead of using `surrogate_optimize!`, the user will use `potential_optimal_points`. This will return the coordinates of points that the optimizer has determined are most useful to evaluate next. How the user evaluates these points is up to them. The Ask-Tell interface requires more manual control than `surrogate_optimize!`, but it allows for more flexibility. After the point has been evaluated, the user will *tell* the surrogate model the new points with the `update!` function.

--- a/docs/src/polychaos.md
+++ b/docs/src/polychaos.md
@@ -2,6 +2,10 @@
 
 We can create a surrogate using a polynomial expansion, with a different polynomial basis depending on the distribution of the data we are trying to fit. Under the hood, PolyChaos.jl has been used. It is possible to specify a type of polynomial for each dimension of the problem.
 
+```@docs
+PolynomialChaosSurrogate
+```
+
 ## Sampling
 
 We choose to sample f in 100 points between 0 and 10 using the `sample` function. The sampling points are chosen using a Low Discrepancy. This can be done by passing `HaltonSample()` to the `sample` function.

--- a/docs/src/radials.md
+++ b/docs/src/radials.md
@@ -2,6 +2,13 @@
 
 The Radial Basis Surrogate model represents the interpolating function as a linear combination of basis functions, one for each training point. Let's say we are building a surrogate for:
 
+```@docs
+linearRadial
+cubicRadial
+multiquadricRadial
+thinplateRadial
+```
+
 ```math
 f(x) = \log(x) \cdot x^2+x^3
 ```

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -2,6 +2,19 @@
 
 Sampling methods are provided by the [QuasiMonteCarlo package](https://docs.sciml.ai/QuasiMonteCarlo/stable/).
 
+```@docs
+SamplingAlgorithm
+sample
+GridSample
+RandomSample
+SobolSample
+LatinHypercubeSample
+HaltonSample
+KroneckerSample
+GoldenSample
+SectionSample
+```
+
 The syntax for sampling in an interval or region is the following:
 
 ```julia

--- a/docs/src/samples.md
+++ b/docs/src/samples.md
@@ -3,16 +3,8 @@
 Sampling methods are provided by the [QuasiMonteCarlo package](https://docs.sciml.ai/QuasiMonteCarlo/stable/).
 
 ```@docs
-SamplingAlgorithm
-sample
-GridSample
-RandomSample
-SobolSample
-LatinHypercubeSample
-HaltonSample
-KroneckerSample
-GoldenSample
-SectionSample
+Surrogates.sample
+Surrogates.SectionSample
 ```
 
 The syntax for sampling in an interval or region is the following:

--- a/docs/src/secondorderpoly.md
+++ b/docs/src/secondorderpoly.md
@@ -2,6 +2,10 @@
 
 The square polynomial model can be expressed by:
 
+```@docs
+SecondOrderPolynomialSurrogate
+```
+
 ``y = Xβ + ϵ``
 
 Where X is the matrix of the linear model augmented by adding 2d columns,

--- a/docs/src/surrogate.md
+++ b/docs/src/surrogate.md
@@ -7,6 +7,13 @@ Every surrogate has a different definition depending on the parameters needed. I
 
 The first function adds a sample point to the surrogate, thus changing the internal coefficients. The second one calculates the approximation at value.
 
+```@docs
+AbstractSurrogate
+current_surrogates
+std_error_at_point
+update!
+```
+
   - Linear surrogate
 
 ```@docs
@@ -48,6 +55,27 @@ XGBoostSurrogate(x,y,lb,ub;num_round::Int = 1)
 
 ```
 NeuralSurrogate(x,y,lb,ub; model = Chain(Dense(length(x[1]),1), first), loss = (x,y) -> Flux.mse(model(x), y),opt = Descent(0.01),n_echos::Int = 1)
+```
+
+```@docs
+EarthSurrogate
+NeuralSurrogate
+SVMSurrogate
+```
+
+## Structure Descriptors
+
+```@docs
+RadialBasisStructure
+KrigingStructure
+LinearStructure
+InverseDistanceStructure
+LobachevskyStructure
+NeuralStructure
+GENNStructure
+XGBoostStructure
+SecondOrderPolynomialStructure
+WendlandStructure
 ```
 
 # Creating another surrogate

--- a/docs/src/surrogate.md
+++ b/docs/src/surrogate.md
@@ -59,7 +59,6 @@ NeuralSurrogate(x,y,lb,ub; model = Chain(Dense(length(x[1]),1), first), loss = (
 
 ```@docs
 EarthSurrogate
-NeuralSurrogate
 SVMSurrogate
 ```
 

--- a/docs/src/variablefidelity.md
+++ b/docs/src/variablefidelity.md
@@ -2,6 +2,10 @@
 
 With the variable fidelity surrogate, we can specify two different surrogates: one for high-fidelity data and one for low-fidelity data. By default, the first half of the samples are considered high-fidelity and the second half low-fidelity.
 
+```@docs
+VariableFidelitySurrogate
+```
+
 ```@example variablefid
 using Surrogates
 using Plots

--- a/docs/src/wendland.md
+++ b/docs/src/wendland.md
@@ -3,6 +3,10 @@
 The Wendland surrogate is a compact surrogate: it allocates much less memory than other surrogates.
 The coefficients are found using an iterative solver.
 
+```@docs
+Wendland
+```
+
 ``f = x -> exp(-x^2)``
 
 ```@example wendland

--- a/docs/src/xgboost.md
+++ b/docs/src/xgboost.md
@@ -2,6 +2,10 @@
 
 Random forests is a supervised learning algorithm that randomly creates and merges multiple decision trees into one forest.
 
+```@docs
+XGBoostSurrogate
+```
+
 We are going to use a xgboost surrogate to optimize $f(x)=sin(x)+sin(10/3 * x)$.
 
 First of all import `Surrogates`, `XGBoost` and `Plots`.

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -1,6 +1,43 @@
 using QuasiMonteCarlo
 using QuasiMonteCarlo: SamplingAlgorithm
 
+"""
+    sample(n, lb, ub, sampler::SamplingAlgorithm; kwargs...)
+
+Generate sample points for a surrogate model using a QuasiMonteCarlo sampling algorithm.
+Surrogates.jl wraps `QuasiMonteCarlo.sample` and converts its matrix output to the
+historical Surrogates.jl representation: a vector for one-dimensional samples and a
+vector of tuples for multidimensional samples.
+
+# Arguments
+
+- `n::Integer`: Number of sample points to generate.
+- `lb`: Lower bound for the sampled domain. Use a number for one-dimensional domains
+    or a vector/tuple for multidimensional domains.
+- `ub`: Upper bound for the sampled domain. It must have the same dimensionality as
+    `lb`.
+- `sampler::SamplingAlgorithm`: Sampling strategy such as `SobolSample()`,
+    `RandomSample()`, or `HaltonSample()`.
+
+# Keywords
+
+- `kwargs...`: Additional keyword arguments forwarded to `QuasiMonteCarlo.sample`.
+
+# Returns
+
+- For one-dimensional bounds, a vector of sampled values.
+- For multidimensional bounds, a vector of tuples whose entries are sample
+    coordinates.
+
+# Examples
+
+```julia
+using Surrogates
+
+x = sample(5, 0.0, 1.0, SobolSample())
+xy = sample(5, [0.0, 0.0], [1.0, 1.0], SobolSample())
+```
+"""
 # We need to convert the matrix that QuasiMonteCarlo produces into a vector of Tuples like Surrogates expects
 # This will eventually be removed once we refactor the rest of the code to work with d x n matrices instead
 # of vectors of Tuples
@@ -17,9 +54,33 @@ end
 
 #### SectionSample ####
 """
-    SectionSample{T}(x0, sa)
+    SectionSample(x0::AbstractVector, sampler::SamplingAlgorithm)
 
-`SectionSample(x0, sampler)` where `sampler` is any sampler above and `x0` is a vector of either `NaN` for a free dimension or some scalar for a constrained dimension.
+Sampling algorithm that keeps selected dimensions fixed while sampling the remaining
+dimensions. In `x0`, entries equal to `NaN` are free dimensions, and numeric entries
+are fixed coordinates.
+
+# Arguments
+
+- `x0::AbstractVector`: Section definition. Use `NaN` for coordinates that should be
+    sampled and finite numbers for coordinates that should remain fixed.
+- `sampler::SamplingAlgorithm`: Sampling strategy to use on the free dimensions.
+
+# Fields
+
+- `x0`: Section definition supplied to the constructor.
+- `sa`: Sampling algorithm used for the free dimensions.
+- `fixed_dims`: Indices cached by the constructor for `sample(n, section)`. For the
+    default constructor, these are the coordinates where `x0` is `NaN`.
+
+# Examples
+
+```julia
+using Surrogates
+
+section = SectionSample([NaN, 0.5], SobolSample())
+sample(4, [0.0, 0.0], [1.0, 1.0], section)
+```
 """
 struct SectionSample{
         R <: Real,


### PR DESCRIPTION
## Summary

This draft PR should be ignored until reviewed by @ChrisRackauckas.

- widens SciMLTesting compat in the root and QA environments to allow v2.1+ while preserving existing v1 support
- adds package-owned public API docstrings surfaced by SciMLTesting v2 QA
- adds rendered `@docs` entries for the public APIs in the existing docs pages

## Local verification

- PASS: `timeout 3600 git diff --check`
- PASS: `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/depots/Surrogates /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e ...` TOML parse/assert for `SciMLTesting = "1, 2.1"` and QA `SciMLTesting = "1.6, 2.1"`
- PASS: Runic.jl v1.7.0 check via local tool env: `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/depots/Surrogates /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/toolenvs/runic -e 'using Runic; exit(Runic.main(["--check", "."]))'`\n- PASS: `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/depots/Surrogates JULIA_PROJECT=test/qa /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e 'using SciMLTesting, Surrogates; run_api_docs(Surrogates; rendered=true)'`\n- PASS: QA with SciMLTesting v2 selected: `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/depots/Surrogates JULIA_PROJECT=test/qa /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e 'using Pkg; Pkg.instantiate(); deps = collect(values(Pkg.dependencies())); sciml = only(filter(dep -> dep.name == "SciMLTesting", deps)); surr = only(filter(dep -> dep.name == "Surrogates", deps)); @assert sciml.version >= v"2.1.0" sciml.version; @assert surr.is_direct_dep; println("SciMLTesting version: ", sciml.version); println("Surrogates path: ", something(surr.source, "")); include("test/qa/qa.jl")'` resolved `SciMLTesting v2.2.0`, used the local checkout, and reported `Quality Assurance | 16 pass, 1 broken, 17 total`.\n- TIMEOUT: root `Pkg.test(; coverage=false)` with `timeout 3600` and the same local depot resolved `SciMLTesting v2.2.0` and the local checkout, but timed out after one hour while still running `test/AD_compatibility.jl:310` in GENN/Flux training after reaching epoch 400 of a fourth training segment. No assertion failure was reached before timeout.\n\n## Notes\n\nThe root test suite is broad and long-running for this targeted compat/doc rollout; the focused SciMLTesting v2 QA path completed successfully locally.\n