### PR TITLE
Bump Surrogates to v7.5.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.5.2"
+version = "7.5.3"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `Surrogates` **v7.5.2 → v7.5.3** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Merge pull request #568 from ChrisRackauckas-Claude/agent/scimltesting-v2-compat (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)