### PR TITLE
Scan package extensions in the QA group

### DIFF
--- a/ext/SurrogatesAbstractGPsExt.jl
+++ b/ext/SurrogatesAbstractGPsExt.jl
@@ -1,6 +1,6 @@
 module SurrogatesAbstractGPsExt
 
-using Surrogates: AbstractGPSurrogate, logpdf_surrogate, std_error_at_point, Surrogates
+using Surrogates: AbstractGPSurrogate, Surrogates
 using SurrogatesBase, AbstractGPs
 
 # constructor

--- a/ext/SurrogatesFluxExt.jl
+++ b/ext/SurrogatesFluxExt.jl
@@ -1,6 +1,6 @@
 module SurrogatesFluxExt
 
-using Surrogates: NeuralSurrogate, Surrogates, GENNSurrogate, predict_derivative
+using Surrogates: NeuralSurrogate, Surrogates, GENNSurrogate
 using SurrogatesBase
 using Flux: Flux.Optimisers
 using Flux

--- a/ext/SurrogatesMOEExt.jl
+++ b/ext/SurrogatesMOEExt.jl
@@ -1,9 +1,7 @@
 module SurrogatesMOEExt
 
-import Surrogates: linearRadial, cubicRadial, multiquadricRadial,
-    thinplateRadial, RadialBasisStructure, RadialBasis,
+import Surrogates: RadialBasis,
     InverseDistanceSurrogate, Kriging, LobachevskyStructure,
-    LobachevskySurrogate, NeuralStructure, PolyChaosStructure,
     LinearSurrogate, MOE,
     NeuralSurrogate, XGBoostSurrogate, PolynomialChaosSurrogate
 using SurrogatesBase

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,29 @@
 [deps]
+AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+GaussianMixtures = "cc18c42c-b769-54ff-9e2a-b28141a64aae"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
+PolyChaos = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Surrogates = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [sources]
 Surrogates = {path = "../.."}
 
 [compat]
+AbstractGPs = "0.5.18"
 Aqua = "0.8"
+Flux = "0.16.2"
+GaussianMixtures = "0.3.13"
 JET = "0.9, 0.10"
+LIBSVM = "0.8"
+Optimisers = "0.4.4"
+PolyChaos = "1.0"
 SciMLTesting = "2.1"
+XGBoost = "2.4.1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,27 @@
 using SciMLTesting, Surrogates, Test
 using JET
 
+# ExplicitImports can only see an extension module once its trigger package is
+# loaded, so load every weakdep here to bring the extensions under QA.
+using AbstractGPs, Flux, GaussianMixtures, LIBSVM, Optimisers, PolyChaos, XGBoost
+
+const SURROGATE_EXTENSIONS = (
+    :SurrogatesAbstractGPsExt,
+    :SurrogatesFluxExt,
+    :SurrogatesMOEExt,
+    :SurrogatesPolyChaosExt,
+    :SurrogatesSVMExt,
+    :SurrogatesXGBoostExt,
+)
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    for ext in SURROGATE_EXTENSIONS
+        @test Base.get_extension(Surrogates, ext) !== nothing
+    end
+end
+
 run_qa(
     Surrogates;
     explicit_imports = true,


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Why

`SciMLTesting.run_qa` runs ExplicitImports on the package module. ExplicitImports *does*
know about extensions — it reads the `[extensions]` table out of `Project.toml` — but it
skips any extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep has been loaded, and
`test/qa/Project.toml` had none of them. So on `master` the QA group scans `Surrogates`
and nothing else.

Verified directly on unmodified `master` (`julia --project=test/qa`):

```
SurrogatesAbstractGPsExt => nothing
SurrogatesFluxExt        => nothing
SurrogatesMOEExt         => nothing
SurrogatesPolyChaosExt   => nothing
SurrogatesSVMExt         => nothing
SurrogatesXGBoostExt     => nothing
SCANNED: Surrogates
```

This is a real gap, not an incidental one — none of the weakdeps are pulled in
transitively by the existing QA deps.

## What this PR does

* Adds all seven weakdeps to `test/qa/Project.toml` `[deps]` + `[compat]`, mirroring the
  root `Project.toml` bounds.
* `using`s them in `test/qa/qa.jl` so the extension modules exist before `run_qa`.
* Adds an `Extensions loaded` testset asserting `Base.get_extension` is non-`nothing` for
  each of the six extensions. Without it, an extension that stopped precompiling would be
  silently skipped and QA would still go green with zero extension coverage.

After the change, same probe:

```
SurrogatesAbstractGPsExt => SurrogatesAbstractGPsExt
SurrogatesFluxExt        => SurrogatesFluxExt
SurrogatesMOEExt         => SurrogatesMOEExt
SurrogatesPolyChaosExt   => SurrogatesPolyChaosExt
SurrogatesSVMExt         => SurrogatesSVMExt
SurrogatesXGBoostExt     => SurrogatesXGBoostExt
SCANNED: Surrogates
SCANNED: SurrogatesFluxExt
SCANNED: SurrogatesSVMExt
SCANNED: SurrogatesXGBoostExt
SCANNED: SurrogatesMOEExt
SCANNED: SurrogatesPolyChaosExt
SCANNED: SurrogatesAbstractGPsExt
```

All six extensions are covered; nothing is left out. (`Optimisers` is a declared weakdep
but triggers no extension — `SurrogatesFluxExt` reaches it as `Flux.Optimisers` — so
adding it changes no coverage; it is included for completeness and costs nothing since
Flux already depends on it.)

## Findings, and how they were handled

All were `no_stale_explicit_imports` failures in the newly scanned extensions, fixed at
the source rather than ignored:

* `SurrogatesFluxExt` imported `predict_derivative` but defines the method qualified as
  `Surrogates.predict_derivative`, so the import was never used.
* `SurrogatesAbstractGPsExt` imported `logpdf_surrogate` and `std_error_at_point` for the
  same reason.
* `SurrogatesMOEExt` imported `linearRadial`, `cubicRadial`, `multiquadricRadial`,
  `thinplateRadial`, `RadialBasisStructure`, `LobachevskySurrogate`, `NeuralStructure`
  and `PolyChaosStructure` and used none of them. `PolyChaosStructure` is also not public
  in `Surrogates`, so dropping it clears an `all_explicit_imports_are_public` failure too.

**No new ignore entries were added.** The remaining improper imports/accesses all live in
`Surrogates` itself and are already covered by the existing ignore tuples.

`no_implicit_imports` stays in `ei_broken` (tracked in #564); the extensions add to that
list but do not change its status.

## Local QA result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on Julia 1.12.6, this branch:

```
Test Summary:                                  | Pass  Fail  Broken  Total     Time
QA/qa.jl                                       |   25     1       1     27  2m39.7s
  Extensions loaded                            |    6                    6     0.7s
  Quality Assurance                            |   19     1       1     21  2m25.9s
    ...
    ExplicitImports                            |    5             1      6    30.8s
    Public API documentation                   |    2                    2     8.2s
    No unapproved public reexports             |          1              1     4.1s
```

Every ExplicitImports check passes with all six extensions loaded.

### The one remaining failure is pre-existing on `master`

`No unapproved public reexports` fails identically on unmodified `master` in this
environment:

```
Test Summary:                                  | Pass  Fail  Broken  Total     Time
QA/qa.jl                                       |   19     1       1     21  2m40.4s
  Quality Assurance                            |   19     1       1     21  2m31.7s
    ...
    No unapproved public reexports             |          1              1     4.6s
```

```
Evaluated: isempty([:GoldenSample, :GridSample, :HaltonSample, :KroneckerSample,
                    :LatinHypercubeSample, :RandomSample, :SamplingAlgorithm,
                    :SobolSample, :update!])
```

These are the sampling names re-exported from QuasiMonteCarlo plus `update!` from
SurrogatesBase — the same set already listed in `api_docs_kwargs.rendered_ignore`. It
looks like a newer `SciMLTesting` added the reexports check and `qa.jl` has no matching
`reexports_allow`. Deliberately left out of this PR to keep it focused on extension
coverage; it wants its own fix.
