### PR TITLE
Import QuasiMonteCarlo in tests instead of using it

### DIFF
--- a/test/inverseDistanceSurrogate.jl
+++ b/test/inverseDistanceSurrogate.jl
@@ -1,6 +1,6 @@
 using Surrogates
 using Test
-using QuasiMonteCarlo
+import QuasiMonteCarlo
 #1D
 obj = x -> sin(x) + sin(x)^2 + sin(x)^3
 lb = 0.0

--- a/test/optimization.jl
+++ b/test/optimization.jl
@@ -1,6 +1,6 @@
 using Surrogates
 using LinearAlgebra
-using QuasiMonteCarlo
+import QuasiMonteCarlo
 using LIBSVM
 #######SRBF############
 ##### 1D #####


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`Core` is red on master, independent of any PR content — e.g. https://github.com/SciML/Surrogates.jl/actions/runs/30770574923/job/91557093851:

```
Core/inverseDistanceSurrogate.jl: Error During Test
  LoadError: UndefVarError: `sample` not defined in `Main.var"##Core/inverseDistanceSurrogate.jl#586"`
  Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity.
  Hint: a global variable of this name also exists in Surrogates.
  Hint: a global variable of this name also exists in QuasiMonteCarlo.
  @ test/inverseDistanceSurrogate.jl:8
```

`Surrogates.sample` (src/Sampling.jl) is its own binding, not an extension of `QuasiMonteCarlo.sample` — it wraps the QMC matrix output back into the historical vector / vector-of-tuples representation. A test file that does `using Surrogates` *and* `using QuasiMonteCarlo` therefore has two different `sample` bindings in scope, and the unqualified call errors.

## Fix

`import QuasiMonteCarlo` instead of `using QuasiMonteCarlo` in the two affected files. The dependency stays declared, but its exports no longer enter the test module, so `sample` resolves unambiguously to `Surrogates.sample`. Every sampler these files name (`HaltonSample`, `SobolSample`, `RandomSample`, `SectionSample`) is exported by Surrogates itself, so nothing else changes.

`test/sampling.jl` and `test/SectionSampleTests.jl` also `using` both packages but already qualify `Surrogates.sample` everywhere, so they are untouched — `test/sampling.jl` genuinely needs QMC's exports (`LatticeRuleSample`, `NoRand`).

## Verification

Julia 1.12.6, local env with Surrogates dev'd:

- Before: `test/inverseDistanceSurrogate.jl` errors with the `UndefVarError` above.
- After: `julia --project test/inverseDistanceSurrogate.jl` → exit 0.
- After: `julia --project -e 'using Test; include("test/optimization.jl")'` → exit 0 (this file has the same latent ambiguity at line 67; the CI run never got that far because it aborted earlier).
- Unchanged files still pass: `test/sampling.jl` → exit 0, `test/SectionSampleTests.jl` → exit 0.
- `Runic --check` clean on both changed files.

## Not addressed here

The `QA` job on the same run has two separate pre-existing failures (Aqua `Persistent tasks`, and `No unapproved public reexports` listing `GoldenSample`, `GridSample`, `HaltonSample`, `KroneckerSample`, `LatinHypercubeSample`, `RandomSample`, `SamplingAlgorithm`, `SobolSample`, `update!`). Those come from `using QuasiMonteCarlo` in `src/Sampling.jl` combined with re-exporting its samplers, and are a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oL1c43GTJJkEwPXzFWMoe