### PR TITLE
Bump version to 7.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.5.5"
+version = "7.6.0"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
## Version bump: 7.5.5 → 7.6.0 (minor)

There are 3 commits and 3 src/ file changes since v7.5.5:
- New feature: KPLS and KPLSK surrogate methods (#580)
- Update QuasiMonteCarlo compat (#582)
- Drop older SciML major versions from compat (#583)

Minor bump is appropriate since #580 adds new surrogate methods (KPLS and KPLSK), which is a feature addition.

> **Note:** This PR should be ignored until reviewed by @ChrisRackauckas.