### PR TITLE
refactor: RadialBasis

### DIFF
--- a/docs/src/surrogate.md
+++ b/docs/src/surrogate.md
@@ -102,7 +102,6 @@ NeuralSurrogate(x,y,lb,ub; model = Chain(Dense(length(x[1]),1), first), loss = (
 ```
 
 ```@docs
-EarthSurrogate
 SVMSurrogate
 ```
 

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -124,8 +124,10 @@ A `RadialFunction` with polynomial degree `2` and basis
 """
 thinplateRadial() = RadialFunction(
     2, z -> begin
-        result = norm(z)^2 * log(norm(z))
-        ifelse(iszero(z), zero(result), result)
+        # On the radius, not on `z`: `iszero` of a tuple is a `MethodError`, so
+        # testing `z` made this kernel unusable for multidimensional inputs.
+        r = norm(z)
+        iszero(r) ? zero(r * r) : r^2 * log(r)
     end
 )
 
@@ -135,62 +137,39 @@ function RadialBasis(
     )
     q = rad.q
     phi = rad.phi
-    coeff = _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse, regularization)
-    return RadialBasis(phi, q, x, y, lb, ub, coeff, scale_factor, sparse, regularization)
+    # At the samples' own precision. The distance is divided by one and the
+    # interpolation matrix has the other added to its diagonal, so leaving
+    # either at its Float64 default carries a Float32 design into Float64.
+    T = float(eltype(first(x)))
+    scale = convert(T, scale_factor)
+    reg = convert(T, regularization)
+    coeff = _calc_coeffs(x, y, phi, scale, sparse, reg)
+    return RadialBasis(phi, q, x, y, lb, ub, coeff, scale, sparse, reg)
 end
 
-function _calc_coeffs(x, y, lb, ub, phi, q, scale_factor, sparse, regularization)
-    nd = length(first(x))
-    num_poly_terms = binomial(q + nd, q)
-    D = _construct_rbf_interp_matrix(x, first(x), lb, ub, phi, q, scale_factor, sparse)
+function _calc_coeffs(x, y, phi, scale_factor, sparse, regularization)
+    D = _construct_rbf_interp_matrix(x, phi, scale_factor, sparse)
     D += regularization * I # Add regularization to the diagonal
-    Y = _construct_rbf_y_matrix(y, first(y), length(y) + num_poly_terms)
-    if (typeof(y) == Vector{Float64}) #single output case
-        coeff = _copy(transpose(D \ y))
-    else
-        coeff = _copy(transpose(D \ Y[1:size(D)[1], :])) #if y is multi output;
-    end
-    return coeff
+    # One coefficient row per output; a scalar response gives a 1 x n row.
+    return _copy(transpose(D \ _construct_y_matrix(y, first(y))))
 end
 
-function _construct_rbf_interp_matrix(x, x_el::Number, lb, ub, phi, q, scale_factor, sparse)
+# The kernel reads a pair of samples through broadcasting, so a scalar and a
+# multidimensional sample are assembled the same way and one method serves both.
+function _construct_rbf_interp_matrix(x, phi, scale_factor, sparse)
     n = length(x)
-    if sparse
-        D = ExtendableSparseMatrix{eltype(x_el), Int}(n, n)
-    else
-        D = zeros(eltype(x_el), n, n)
-    end
+    # `float` because `phi` returns a distance: an integer design would
+    # otherwise throw `InexactError` for any scale the samples do not divide.
+    T = float(eltype(first(x)))
+    D = sparse ? ExtendableSparseMatrix{T, Int}(n, n) : zeros(T, n, n)
     @inbounds for i in 1:n
+        # The kernel depends only on the difference and is even in it, so only
+        # the triangle `Symmetric` reads has to be filled.
         for j in i:n
             D[i, j] = phi((x[i] .- x[j]) ./ scale_factor)
         end
     end
-    D_sym = Symmetric(D, :U)
-    return D_sym
-end
-
-function _construct_rbf_interp_matrix(x, x_el, lb, ub, phi, q, scale_factor, sparse)
-    n = length(x)
-    nd = length(x_el)
-    if sparse
-        D = ExtendableSparseMatrix{eltype(x_el), Int}(n, n)
-    else
-        D = zeros(eltype(x_el), n, n)
-    end
-    @inbounds for i in 1:n
-        for j in i:n
-            D[i, j] = phi((x[i] .- x[j]) ./ scale_factor)
-        end
-    end
-    D_sym = Symmetric(D, :U)
-    return D_sym
-end
-
-function _construct_rbf_y_matrix(y, y_el::Number, m)
-    return [i <= length(y) ? y[i] : zero(y_el) for i in 1:m]
-end
-function _construct_rbf_y_matrix(y, y_el, m)
-    return [i <= length(y) ? y[i][j] : zero(first(y_el)) for i in 1:m, j in 1:length(y_el)]
+    return Symmetric(D, :U)
 end
 
 using Zygote: Buffer
@@ -303,7 +282,14 @@ function _approx_rbf(val, rad::RadialBasis)
     n = length(rad.x)
 
     if n > size(rad.coeff, 2)
-        throw("Length of model's x vector exceeds number of calculated coefficients ($n != $(size(rad.coeff, 2))).")
+        throw(
+            ArgumentError(
+                "RadialBasis has $n samples but only $(size(rad.coeff, 2)) \
+                coefficients. The sample and coefficient containers have fallen \
+                out of step; rebuild the surrogate, or use update! to add \
+                samples so the coefficients are refitted with them."
+            )
+        )
     end
 
     approx = _make_approx(val, rad)
@@ -338,17 +324,9 @@ _center_bounds(x, lb, ub) = (ub .- lb) ./ 2
 Add new samples x and y and update the coefficients. Return the new object radial.
 """
 function SurrogatesBase.update!(rad::RadialBasis, new_x, new_y)
-    if (length(new_x) == 1 && length(new_x[1]) == 1) ||
-            (length(new_x) > 1 && length(new_x[1]) == 1 && length(rad.lb) > 1)
-        push!(rad.x, new_x)
-        push!(rad.y, new_y)
-    else
-        append!(rad.x, new_x)
-        append!(rad.y, new_y)
-    end
+    rad.x, rad.y = _append_samples(rad.x, rad.y, new_x, new_y)
     rad.coeff = _calc_coeffs(
-        rad.x, rad.y, rad.lb, rad.ub, rad.phi, rad.dim_poly,
-        rad.scale_factor, rad.sparse, rad.regularization
+        rad.x, rad.y, rad.phi, rad.scale_factor, rad.sparse, rad.regularization
     )
     return nothing
 end

--- a/src/Radials.jl
+++ b/src/Radials.jl
@@ -103,14 +103,33 @@ Construct the multiquadric radial basis function used by
 
 # Arguments
 
-  - `c::Real`: scale parameter inside the multiquadric basis.
+  - `c::Real`: shape parameter inside the multiquadric basis.
 
 # Returns
 
 A `RadialFunction` with polynomial degree `1` and basis
 `z -> sqrt((c * norm(z))^2 + 1)`.
+
+# Note
+
+This is Hardy's multiquadric `sqrt(r^2 + c0^2)` with `c0 = 1 / c`, times a
+constant that the interpolant is invariant to. So `c` runs the *opposite* way to
+the usual shape parameter: a larger `c` gives a peakier basis, not a flatter one.
+
+`c` and `scale_factor` both scale the radius, so they are one parameter between
+them: `multiquadricRadial(2.0)` with `scale_factor = 1.0` gives the same
+interpolant as `multiquadricRadial(1.0)` with `scale_factor = 0.5`.
 """
-multiquadricRadial(c = 1.0) = RadialFunction(1, z -> sqrt((c * norm(z))^2 + 1))
+function multiquadricRadial(c = 1.0)
+    return RadialFunction(
+        1, z -> begin
+            # `c` at the radius' own precision: its `1.0` default is a Float64
+            # literal, which would otherwise carry a Float32 design into Float64.
+            r = norm(z)
+            return sqrt((oftype(r, c) * r)^2 + one(r))
+        end
+    )
+end
 
 """
     thinplateRadial() -> RadialFunction
@@ -124,12 +143,16 @@ A `RadialFunction` with polynomial degree `2` and basis
 """
 thinplateRadial() = RadialFunction(
     2, z -> begin
-        # On the radius, not on `z`: `iszero` of a tuple is a `MethodError`, so
-        # testing `z` made this kernel unusable for multidimensional inputs.
+        # On the radius: `iszero` of a tuple is a `MethodError`, which made
+        # this kernel unusable for multidimensional inputs.
         r = norm(z)
         iszero(r) ? zero(r * r) : r^2 * log(r)
     end
 )
+
+# The closure captures nothing, so one instance identifies the kernel — and
+# calling `linearRadial()` to compare against put a construction in the hot loop.
+const _LINEAR_RADIAL_PHI = linearRadial().phi
 
 function RadialBasis(
         x, y, lb, ub; rad::RadialFunction = linearRadial(),
@@ -137,9 +160,9 @@ function RadialBasis(
     )
     q = rad.q
     phi = rad.phi
-    # At the samples' own precision. The distance is divided by one and the
-    # interpolation matrix has the other added to its diagonal, so leaving
-    # either at its Float64 default carries a Float32 design into Float64.
+    # At the samples' own precision: one divides the distance and the other is
+    # added to the matrix diagonal, so a Float64 default would carry a Float32
+    # design into Float64.
     T = float(eltype(first(x)))
     scale = convert(T, scale_factor)
     reg = convert(T, regularization)
@@ -149,13 +172,14 @@ end
 
 function _calc_coeffs(x, y, phi, scale_factor, sparse, regularization)
     D = _construct_rbf_interp_matrix(x, phi, scale_factor, sparse)
-    D += regularization * I # Add regularization to the diagonal
+    # Guarded: `D += r * I` copies the whole matrix, and the default is zero.
+    iszero(regularization) || (D += regularization * I)
     # One coefficient row per output; a scalar response gives a 1 x n row.
     return _copy(transpose(D \ _construct_y_matrix(y, first(y))))
 end
 
-# The kernel reads a pair of samples through broadcasting, so a scalar and a
-# multidimensional sample are assembled the same way and one method serves both.
+# Broadcasting reads a scalar and a multidimensional sample the same way, so one
+# method serves both.
 function _construct_rbf_interp_matrix(x, phi, scale_factor, sparse)
     n = length(x)
     # `float` because `phi` returns a distance: an integer design would
@@ -234,53 +258,30 @@ end
 Calculates current estimate of value 'val' with respect to the RadialBasis object.
 """
 function (rad::RadialBasis)(val)
-    # Check to make sure dimensions of input matches expected dimension of surrogate
     _check_dimension(rad, val)
 
     approx = _approx_rbf(val, rad)
     return _match_container(approx, first(rad.y))
 end
 
-function _approx_rbf(val::Number, rad::RadialBasis)
-    n = length(rad.x)
-    approx = zero(rad.coeff[:, 1])
-    for i in 1:n
-        approx += rad.coeff[:, i] * rad.phi((val .- rad.x[i]) / rad.scale_factor)
-    end
-    return approx
-end
+# The accumulator holds coefficient times kernel value, so its type is the
+# promotion of the two; taking it from the query alone broke integer queries.
+_approx_eltype(val, rad) = promote_type(eltype(val), eltype(rad.coeff))
 
+# Zygote cannot trace `setindex!`, so the multi-output accumulator is one of its
+# buffers rather than a plain array.
 function _make_approx(val, rad::RadialBasis)
-    l = size(rad.coeff, 1)
-    return Buffer(zeros(eltype(val), l), false)
+    return Buffer(zeros(_approx_eltype(val, rad), size(rad.coeff, 1)), false)
 end
-function _add_tmp_to_approx!(approx, i, tmp, rad::RadialBasis; f = identity)
+
+function _add_tmp_to_approx!(approx, i, kernel, rad::RadialBasis)
     return @inbounds @simd ivdep for j in 1:size(rad.coeff, 1)
-        approx[j] += rad.coeff[j, i] * f(tmp)
-    end
-end
-function _make_approx(
-        val,
-        ::RadialBasis{F, Q, X, <:AbstractArray{<:Number}}
-    ) where {F, Q, X}
-    return Ref(zero(eltype(val)))
-end
-function _add_tmp_to_approx!(
-        approx::Base.RefValue, i, tmp,
-        rad::RadialBasis{F, Q, X, <:AbstractArray{<:Number}};
-        f = identity
-    ) where {F, Q, X}
-    return @inbounds @simd ivdep for j in 1:size(rad.coeff, 1)
-        approx[] += rad.coeff[j, i] * f(tmp)
+        approx[j] += rad.coeff[j, i] * kernel
     end
 end
 
-_ret_copy(v::Base.RefValue) = v[]
-_ret_copy(v) = copy(v)
-
-function _approx_rbf(val, rad::RadialBasis)
+function _check_coeff_count(rad::RadialBasis)
     n = length(rad.x)
-
     if n > size(rad.coeff, 2)
         throw(
             ArgumentError(
@@ -291,27 +292,57 @@ function _approx_rbf(val, rad::RadialBasis)
             )
         )
     end
+    return n
+end
+
+function _approx_rbf(val, rad::RadialBasis)
+    n = _check_coeff_count(rad)
 
     approx = _make_approx(val, rad)
-
-    if rad.phi === linearRadial().phi
-        for i in 1:n
-            tmp = zero(eltype(val))
-            @inbounds @simd ivdep for j in 1:length(val)
-                tmp += ((val[j] - rad.x[i][j]) / rad.scale_factor)^2
-            end
-            tmp = sqrt(tmp)
-            _add_tmp_to_approx!(approx, i, tmp, rad)
+    if rad.phi === _LINEAR_RADIAL_PHI
+        @inbounds for i in 1:n
+            _add_tmp_to_approx!(approx, i, _linear_distance(val, rad, i), rad)
         end
     else
-        tmp = collect(val)
         @inbounds for i in 1:n
-            tmp = (val .- rad.x[i]) ./ rad.scale_factor
-            _add_tmp_to_approx!(approx, i, tmp, rad; f = rad.phi)
+            _add_tmp_to_approx!(
+                approx, i, rad.phi((val .- rad.x[i]) ./ rad.scale_factor), rad
+            )
         end
     end
+    return copy(approx)
+end
 
-    return _ret_copy(approx)
+# A scalar response has a single coefficient row, so it accumulates into a local
+# rather than a buffer: the total stays in a register, and nothing is mutated, so
+# reverse mode differentiates straight through.
+function _approx_rbf(
+        val, rad::RadialBasis{F, Q, X, <:AbstractArray{<:Number}}
+    ) where {F, Q, X}
+    n = _check_coeff_count(rad)
+    approx = zero(_approx_eltype(val, rad))
+    # Hoisted rather than tested per sample, which costs about a third of the
+    # evaluation. `@simd` marks a float reduction into a local, over reads alone.
+    if rad.phi === _LINEAR_RADIAL_PHI
+        @inbounds @simd for i in 1:n
+            approx += rad.coeff[1, i] * _linear_distance(val, rad, i)
+        end
+    else
+        @inbounds for i in 1:n
+            approx += rad.coeff[1, i] * rad.phi((val .- rad.x[i]) ./ rad.scale_factor)
+        end
+    end
+    return approx
+end
+
+# The linear kernel is `norm` itself, so its scaled distance is summed
+# coordinate by coordinate rather than through a temporary difference.
+@inline function _linear_distance(val, rad::RadialBasis, i)
+    tmp = zero(_approx_eltype(val, rad))
+    @inbounds @simd ivdep for j in 1:length(val)
+        tmp += ((val[j] - rad.x[i][j]) / rad.scale_factor)^2
+    end
+    return sqrt(tmp)
 end
 
 _scaled_chebyshev(x, k, lb, ub) = cos(k * acos(-1 + 2 * (x - lb) / (ub - lb)))

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -3,248 +3,309 @@ using Test
 using LinearAlgebra
 using Surrogates
 
-#1D
-lb = 0.0
-ub = 4.0
-x = [1.0, 2.0, 3.0]
-y = [4.0, 5.0, 6.0]
-linear = x -> norm(x)
-cubic = x -> x^3
-λ = 2.3
-multiquadr = x -> sqrt(x^2 + λ^2)
-q = 1
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial())
-est = my_rad(3.0)
-@test est ≈ 6.0
-update!(my_rad, 4.0, 10.0)
-est = my_rad(3.0)
-@test est ≈ 6.0
-update!(my_rad, [3.2, 3.3, 3.4], [8.0, 9.0, 10.0])
-est = my_rad(3.0)
-@test est ≈ 6.0
+@testset "RadialBasis" begin
+    @testset "1D" begin
+        lb = 0.0
+        ub = 4.0
+        x = [1.0, 2.0, 3.0]
+        y = [4.0, 5.0, 6.0]
 
-my_rad = RadialBasis(x, y, lb, ub, rad = cubicRadial())
-q = 2
-my_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
-
-# Test that input dimension is properly checked for 1D radial surrogates
-@test_throws ArgumentError my_rad(Float64[])
-@test_throws ArgumentError my_rad((2.0, 3.0, 4.0))
-
-#ND
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-#bounds = [[0.0, 3.0, 6.0], [4.0, 7.0, 10.0]]
-my_rad = RadialBasis(x, y, lb, ub)
-est = my_rad((1.0, 2.0, 3.0))
-@test est ≈ 4.0
-
-#WITH ADD_POINT, adding singleton
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-#bounds = [[0.0,3.0,6.0],[4.0,7.0,10.0]]
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0)
-update!(my_rad, (9.0, 10.0, 11.0), 10.0)
-est = my_rad((1.0, 2.0, 3.0))
-@test est ≈ 4.0
-
-#WITH ADD_POINT, adding more
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-#bounds = [[0.0,3.0,6.0],[4.0,7.0,10.0]]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-my_rad = RadialBasis(x, y, lb, ub)
-update!(my_rad, [(9.0, 10.0, 11.0), (12.0, 13.0, 14.0)], [10.0, 11.0])
-est = my_rad((1.0, 2.0, 3.0))
-@test est ≈ 4.0
-
-lb = [0.0, 0.0, 0.0]
-ub = [10.0, 10.0, 10.0]
-#bounds = [lb,ub]
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-
-my_rad_ND = RadialBasis(x, y, lb, ub)
-update!(my_rad_ND, (3.5, 4.5, 1.2), 18.9)
-update!(my_rad_ND, [(3.2, 1.2, 6.7), (3.4, 9.5, 7.4)], [25.72, 239.0])
-my_rad_ND = RadialBasis(x, y, lb, ub, rad = cubicRadial())
-my_rad_ND = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
-prediction = my_rad_ND((1.0, 1.0, 1.0))
-
-f = x -> x[1] * x[2]
-lb = [1.0, 2.0]
-ub = [10.0, 8.5]
-x = sample(500, lb, ub, SobolSample())
-push!(x, (1.0, 2.0))
-y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
-@test my_radial_basis((1.0, 2.0)) ≈ 2
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
-@test my_radial_basis((1.0, 2.0)) ≈ 2
-
-f = x -> x[1] * x[2]
-lb = [1.0, 2.0]
-ub = [10.0, 8.5]
-x = sample(5, lb, ub, SobolSample())
-push!(x, (1.0, 2.0))
-y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
-@test my_radial_basis((1.0, 2.0)) ≈ 2
-
-# Test that input dimension is properly checked for ND radial surrogates
-@test_throws ArgumentError my_radial_basis((1.0,))
-@test_throws ArgumentError my_radial_basis((2.0, 3.0, 4.0))
-
-# Multi-output
-f = x -> [x^2, x]
-lb = 1.0
-ub = 10.0
-x = sample(5, lb, ub, SobolSample())
-push!(x, 2.0)
-y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
-my_radial_basis(2.0)
-@test my_radial_basis(2.0) ≈ [4, 2]
-
-f = x -> [x[1] * x[2], x[1] + x[2]^2]
-lb = [1.0, 2.0]
-ub = [10.0, 8.5]
-x = sample(5, lb, ub, SobolSample())
-push!(x, (1.0, 2.0))
-y = f.(x)
-my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
-my_radial_basis((1.0, 2.0))
-@test my_radial_basis((1.0, 2.0)) ≈ [2, 5]
-
-x_new = (2.0, 2.0)
-y_new = f(x_new)
-update!(my_radial_basis, x_new, y_new)
-@test my_radial_basis(x_new) ≈ y_new
-
-#sparse
-
-#1D
-lb = 0.0
-ub = 4.0
-x = [1.0, 2.0, 3.0]
-y = [4.0, 5.0, 6.0]
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), sparse = true)
-
-#ND
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-#bounds = [[0.0, 3.0, 6.0], [4.0, 7.0, 10.0]]
-my_rad = RadialBasis(x, y, lb, ub, sparse = true)
-
-#test to verify multiquadricRadial with default scale_factor
-lb = [0.0, 0.0, 0.0]
-ub = [3.0, 3.0, 3.0]
-n_samples = 100
-g(x) = sqrt(x[1]^2 + x[2]^2 + x[3]^2)
-x = sample(n_samples, lb, ub, SobolSample())
-y = g.(x)
-mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
-@test isapprox(mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = 0.0001)
-mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(0.9)) # different shape parameter should not be as accurate
-@test !isapprox(mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = 0.0001)
-
-# Issue 316
-
-x = sample(1024, [-0.45, -0.4, -0.9], [0.4, 0.55, 0.35], SobolSample())
-lb = [-0.45 -0.4 -0.9]
-ub = [0.4 0.55 0.35]
-
-function mockvalues(in)
-    x, y, z = in
-    p1 = reverse(vec([1.09903695e+1 -1.015005e+1 -4.0662974e+1 -1.41834931e+1 1.00604784e+1 4.34951623e+0 -1.06519689e-1 -1.93335202e-3]))
-    p2 = vec([2.12791877 2.12791877 4.23881665 -1.05464575])
-    f = evalpoly(z, p1)
-    f += p2[1] * x^2 + p2[2] * y^2 + p2[3] * x^2 * y + p2[4] * x * y^2
-    return f
-end
-
-y = mockvalues.(x)
-rbf = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(1.788))
-test = (lb .+ ub) ./ 2
-@test isapprox(rbf(test), mockvalues(test), atol = 0.001)
-
-# Test regularization parameter
-# Check the tests still pass with a small regularization parameter
-# 1D
-lb = 0.0
-ub = 4.0
-x = [1.0, 2.0, 3.0]
-y = [4.0, 5.0, 6.0]
-my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = 1.0e-12)
-est = my_rad(3.0)
-@test est ≈ 6.0
-update!(my_rad, 4.0, 10.0)
-est = my_rad(3.0)
-@test est ≈ 6.0
-update!(my_rad, [3.2, 3.3, 3.4], [8.0, 9.0, 10.0])
-est = my_rad(3.0)
-@test est ≈ 6.0
-
-#ND
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-my_rad = RadialBasis(x, y, lb, ub)
-est = my_rad((1.0, 2.0, 3.0))
-@test est ≈ 4.0
-#WITH ADD_POINT, adding singleton
-x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-y = [4.0, 5.0, 6.0]
-lb = [0.0, 3.0, 6.0]
-ub = [4.0, 7.0, 10.0]
-my_rad = RadialBasis(
-    x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0, regularization = 1.0e-12
-)
-update!(my_rad, (9.0, 10.0, 11.0), 10.0)
-est = my_rad((1.0, 2.0, 3.0))
-@test est ≈ 4.0
-
-# Check regularization fixes the SingularException
-# 1D
-for reg in [0, 1.0e-12]
-    local lb = 0.0
-    local ub = 4.0
-    # Pass the first point twice to create a singular matrix
-    # This should throw a SingularException if regularization is not used
-    local x = [1.0, 1.0, 2.0, 3.0]
-    local y = [4.0, 4.0, 5.0, 6.0]
-    if reg == 0
-        @test_throws LinearAlgebra.SingularException RadialBasis(
-            x, y, lb, ub, rad = linearRadial(), regularization = reg
-        )
-    else
-        local my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = reg)
+        my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial())
         @test my_rad(3.0) ≈ 6.0
-        @test my_rad(1.0) ≈ 4.0
-    end
-end
+        update!(my_rad, 4.0, 10.0)
+        @test my_rad(3.0) ≈ 6.0
+        update!(my_rad, [3.2, 3.3, 3.4], [8.0, 9.0, 10.0])
+        @test my_rad(3.0) ≈ 6.0
 
-# ND
-for reg in [0, 1.0e-12]
-    local lb = [0.0, 3.0, 6.0]
-    local ub = [4.0, 7.0, 10.0]
-    local x = [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
-    local y = [4.0, 4.0, 5.0, 6.0]
-    if reg == 0
-        @test_throws LinearAlgebra.SingularException RadialBasis(
-            x, y, lb, ub, rad = linearRadial(), regularization = reg
-        )
-    else
-        local my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = reg)
+        my_rad = RadialBasis(x, y, lb, ub, rad = cubicRadial())
+        my_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
+
+        @test_throws ArgumentError my_rad(Float64[])
+        @test_throws ArgumentError my_rad((2.0, 3.0, 4.0))
+    end
+
+    @testset "ND" begin
+        x = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
+        y = [4.0, 5.0, 6.0]
+        lb = [0.0, 3.0, 6.0]
+        ub = [4.0, 7.0, 10.0]
+
+        my_rad = RadialBasis(x, y, lb, ub)
         @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
-        @test my_rad((4.0, 5.0, 6.0)) ≈ 5.0
+
+        my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), scale_factor = 1.0)
+        update!(my_rad, (9.0, 10.0, 11.0), 10.0)
+        @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
+
+        my_rad = RadialBasis(x, y, lb, ub)
+        update!(my_rad, [(9.0, 10.0, 11.0), (12.0, 13.0, 14.0)], [10.0, 11.0])
+        @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
+
+        lb = [0.0, 0.0, 0.0]
+        ub = [10.0, 10.0, 10.0]
+        my_rad_ND = RadialBasis(x, y, lb, ub)
+        update!(my_rad_ND, (3.5, 4.5, 1.2), 18.9)
+        update!(my_rad_ND, [(3.2, 1.2, 6.7), (3.4, 9.5, 7.4)], [25.72, 239.0])
+        my_rad_ND = RadialBasis(x, y, lb, ub, rad = cubicRadial())
+        my_rad_ND = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
+        prediction = my_rad_ND((1.0, 1.0, 1.0))
+
+        f = x -> x[1] * x[2]
+        lb = [1.0, 2.0]
+        ub = [10.0, 8.5]
+        x = sample(500, lb, ub, SobolSample())
+        push!(x, (1.0, 2.0))
+        y = f.(x)
+        my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        @test my_radial_basis((1.0, 2.0)) ≈ 2
+        my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        @test my_radial_basis((1.0, 2.0)) ≈ 2
+
+        x = sample(5, lb, ub, SobolSample())
+        push!(x, (1.0, 2.0))
+        y = f.(x)
+        my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        @test my_radial_basis((1.0, 2.0)) ≈ 2
+
+        @test_throws ArgumentError my_radial_basis((1.0,))
+        @test_throws ArgumentError my_radial_basis((2.0, 3.0, 4.0))
+    end
+
+    @testset "multi-output" begin
+        f = x -> [x^2, x]
+        lb = 1.0
+        ub = 10.0
+        x = sample(5, lb, ub, SobolSample())
+        push!(x, 2.0)
+        y = f.(x)
+        my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        @test my_radial_basis(2.0) ≈ [4, 2]
+
+        f = x -> [x[1] * x[2], x[1] + x[2]^2]
+        lb = [1.0, 2.0]
+        ub = [10.0, 8.5]
+        x = sample(5, lb, ub, SobolSample())
+        push!(x, (1.0, 2.0))
+        y = f.(x)
+        my_radial_basis = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        @test my_radial_basis((1.0, 2.0)) ≈ [2, 5]
+
+        x_new = (2.0, 2.0)
+        y_new = f(x_new)
+        update!(my_radial_basis, x_new, y_new)
+        @test my_radial_basis(x_new) ≈ y_new
+    end
+
+    @testset "sparse construction" begin
+        lb = 0.0
+        ub = 4.0
+        x = [1.0, 2.0, 3.0]
+        y = [4.0, 5.0, 6.0]
+        my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), sparse = true)
+
+        x_nd = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
+        y_nd = [4.0, 5.0, 6.0]
+        my_rad = RadialBasis(x_nd, y_nd, [0.0, 3.0, 6.0], [4.0, 7.0, 10.0], sparse = true)
+
+        # A sparse assembly of a dense kernel is the same interpolant.
+        dense = RadialBasis(x, y, lb, ub, rad = linearRadial())
+        spars = RadialBasis(x, y, lb, ub, rad = linearRadial(), sparse = true)
+        for p in (1.0, 1.7, 2.5, 3.0)
+            @test dense(p) ≈ spars(p)
+        end
+    end
+
+    @testset "multiquadric shape parameter" begin
+        lb = [0.0, 0.0, 0.0]
+        ub = [3.0, 3.0, 3.0]
+        g(x) = sqrt(x[1]^2 + x[2]^2 + x[3]^2)
+        x = sample(100, lb, ub, SobolSample())
+        y = g.(x)
+        mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial())
+        @test isapprox(mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = 0.0001)
+        # A different shape parameter should not be as accurate.
+        mq_rad = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(0.9))
+        @test !isapprox(mq_rad([2.0, 2.0, 1.0]), g([2.0, 2.0, 1.0]), atol = 0.0001)
+    end
+
+    @testset "issue 316: bounds given as row matrices" begin
+        x = sample(1024, [-0.45, -0.4, -0.9], [0.4, 0.55, 0.35], SobolSample())
+        lb = [-0.45 -0.4 -0.9]
+        ub = [0.4 0.55 0.35]
+
+        # Distinct names: inside a testset these would otherwise be assignments
+        # to the captured `x` and `y` of the enclosing scope, not new locals.
+        function mockvalues(in)
+            xi, yi, zi = in
+            p1 = reverse(
+                vec(
+                    [1.09903695e+1 -1.015005e+1 -4.0662974e+1 -1.41834931e+1 1.00604784e+1 4.34951623e+0 -1.06519689e-1 -1.93335202e-3]
+                )
+            )
+            p2 = vec([2.12791877 2.12791877 4.23881665 -1.05464575])
+            f = evalpoly(zi, p1)
+            f += p2[1] * xi^2 + p2[2] * yi^2 + p2[3] * xi^2 * yi + p2[4] * xi * yi^2
+            return f
+        end
+
+        y = mockvalues.(x)
+        rbf = RadialBasis(x, y, lb, ub, rad = multiquadricRadial(1.788))
+        test = (lb .+ ub) ./ 2
+        @test isapprox(rbf(test), mockvalues(test), atol = 0.001)
+    end
+
+    @testset "regularization" begin
+        lb = 0.0
+        ub = 4.0
+        x = [1.0, 2.0, 3.0]
+        y = [4.0, 5.0, 6.0]
+        my_rad = RadialBasis(x, y, lb, ub, rad = linearRadial(), regularization = 1.0e-12)
+        @test my_rad(3.0) ≈ 6.0
+        update!(my_rad, 4.0, 10.0)
+        @test my_rad(3.0) ≈ 6.0
+        update!(my_rad, [3.2, 3.3, 3.4], [8.0, 9.0, 10.0])
+        @test my_rad(3.0) ≈ 6.0
+
+        x_nd = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
+        y_nd = [4.0, 5.0, 6.0]
+        lb_nd = [0.0, 3.0, 6.0]
+        ub_nd = [4.0, 7.0, 10.0]
+        my_rad = RadialBasis(x_nd, y_nd, lb_nd, ub_nd)
+        @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
+
+        my_rad = RadialBasis(
+            x_nd, y_nd, lb_nd, ub_nd, rad = linearRadial(), scale_factor = 1.0,
+            regularization = 1.0e-12
+        )
+        update!(my_rad, (9.0, 10.0, 11.0), 10.0)
+        @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
+
+        # A repeated sample makes the kernel matrix singular; the diagonal
+        # regularization is what lets the solve go through.
+        for reg in [0, 1.0e-12]
+            local lb = 0.0
+            local ub = 4.0
+            local x = [1.0, 1.0, 2.0, 3.0]
+            local y = [4.0, 4.0, 5.0, 6.0]
+            if reg == 0
+                @test_throws LinearAlgebra.SingularException RadialBasis(
+                    x, y, lb, ub, rad = linearRadial(), regularization = reg
+                )
+            else
+                local my_rad = RadialBasis(
+                    x, y, lb, ub, rad = linearRadial(), regularization = reg
+                )
+                @test my_rad(3.0) ≈ 6.0
+                @test my_rad(1.0) ≈ 4.0
+            end
+        end
+
+        for reg in [0, 1.0e-12]
+            local lb = [0.0, 3.0, 6.0]
+            local ub = [4.0, 7.0, 10.0]
+            local x = [
+                (1.0, 2.0, 3.0), (1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0),
+            ]
+            local y = [4.0, 4.0, 5.0, 6.0]
+            if reg == 0
+                @test_throws LinearAlgebra.SingularException RadialBasis(
+                    x, y, lb, ub, rad = linearRadial(), regularization = reg
+                )
+            else
+                local my_rad = RadialBasis(
+                    x, y, lb, ub, rad = linearRadial(), regularization = reg
+                )
+                @test my_rad((1.0, 2.0, 3.0)) ≈ 4.0
+                @test my_rad((4.0, 5.0, 6.0)) ≈ 5.0
+            end
+        end
+    end
+
+    @testset "every kernel interpolates its samples" begin
+        # The kernels differ in their polynomial degree `q`, but all four are
+        # solved as a plain interpolation system, so each must reproduce the
+        # responses at the nodes it was built from.
+        kernels = (
+            "linear" => linearRadial(), "cubic" => cubicRadial(),
+            "multiquadric" => multiquadricRadial(), "thinplate" => thinplateRadial(),
+        )
+        x = collect(0.0:1.0:5.0)
+        y = [0.0, 1.0, 4.0, 9.0, 16.0, 25.0]
+        for (name, rad) in kernels
+            surr = RadialBasis(x, y, 0.0, 5.0; rad = rad)
+            @test maximum(abs, [surr(p) - v for (p, v) in zip(x, y)]) < 1.0e-8
+        end
+
+        lb = [0.0, 0.0]
+        ub = [4.0, 4.0]
+        x_nd = sample(20, lb, ub, SobolSample())
+        y_nd = [p[1] + p[2] for p in x_nd]
+        for (name, rad) in kernels
+            # thinplateRadial tested `iszero` on the sample difference itself,
+            # which is a `MethodError` for a tuple: this kernel was unusable in
+            # more than one dimension.
+            surr = RadialBasis(x_nd, y_nd, lb, ub; rad = rad)
+            @test surr((2.0, 2.0)) isa Number
+            @test maximum(abs, [surr(p) - v for (p, v) in zip(x_nd, y_nd)]) < 1.0e-6
+        end
+    end
+
+    @testset "thinplate at a node" begin
+        # r^2 log(r) is 0 at r = 0 by continuation, and the kernel has to return
+        # it rather than the NaN that log(0) produces.
+        tp = thinplateRadial().phi
+        @test tp(0.0) == 0.0
+        @test isfinite(tp(0.0))
+        @test tp((0.0, 0.0)) == 0.0
+        @test tp((0.0, 0.0, 0.0)) == 0.0
+        @test tp(2.0) ≈ 4 * log(2)
+    end
+
+    @testset "element types" begin
+        # The interpolation matrix is built in `float(eltype)` of the samples,
+        # and both `scale_factor` and `regularization` are taken to that type:
+        # either left at its Float64 default would carry the whole solve into
+        # Float64.
+        for T in (Float64, Float32, BigFloat)
+            x = T[0, 1, 2, 3]
+            y = T[0, 1, 4, 9]
+            surr = RadialBasis(x, y, T(0), T(3); rad = linearRadial())
+            @test eltype(surr.coeff) == T
+            @test surr(T(1.5)) isa T
+            @test surr(T(2)) ≈ T(4)
+        end
+        # An integer design promotes the way `\` would, and no longer throws
+        # `InexactError` for a scale the samples do not divide.
+        surr = RadialBasis(
+            [0, 1, 2, 3], [0, 1, 4, 9], 0, 3; rad = linearRadial(), scale_factor = 0.3
+        )
+        @test eltype(surr.coeff) == Float64
+        @test surr(2) ≈ 4.0
+        surr = RadialBasis(
+            [0 // 1, 1 // 1, 2 // 1, 3 // 1], [0 // 1, 1 // 1, 4 // 1, 9 // 1],
+            0 // 1, 3 // 1; rad = linearRadial()
+        )
+        @test surr(2 // 1) ≈ 4.0
+    end
+
+    @testset "update! leaves the caller's containers alone" begin
+        # `push!`/`append!` onto the surrogate's fields grew the very vectors
+        # the caller passed in, so building a surrogate mutated its own inputs.
+        x = [1.0, 2.0, 3.0]
+        y = [4.0, 5.0, 6.0]
+        surr = RadialBasis(x, y, 0.0, 5.0; rad = linearRadial())
+        update!(surr, 4.0, 10.0)
+        @test x == [1.0, 2.0, 3.0]
+        @test y == [4.0, 5.0, 6.0]
+        @test length(surr.x) == 4
+        @test surr(4.0) ≈ 10.0
+
+        x_nd = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+        y_nd = [1.0, 2.0, 3.0]
+        surr = RadialBasis(x_nd, y_nd, [0.0, 0.0], [6.0, 7.0]; rad = linearRadial())
+        update!(surr, [(2.0, 3.0), (4.0, 5.0)], [4.0, 5.0])
+        @test length(x_nd) == 3
+        @test length(surr.x) == 5
+        @test surr((2.0, 3.0)) ≈ 4.0
     end
 end

--- a/test/Radials.jl
+++ b/test/Radials.jl
@@ -2,6 +2,8 @@ using Base
 using Test
 using LinearAlgebra
 using Surrogates
+using ForwardDiff
+using Zygote
 
 @testset "RadialBasis" begin
     @testset "1D" begin
@@ -94,6 +96,22 @@ using Surrogates
         y_new = f(x_new)
         update!(my_radial_basis, x_new, y_new)
         @test my_radial_basis(x_new) ≈ y_new
+
+        # Responses may be tuples rather than vectors, and there is nothing
+        # special about two outputs.
+        pts = [(0.0, 0.0), (1.0, 2.0), (2.0, 1.0), (3.0, 3.0), (1.0, 3.0), (4.0, 0.5)]
+        lb2 = [0.0, 0.0]
+        ub2 = [4.0, 4.0]
+        as_tuples = RadialBasis(pts, [(p[1], p[2]) for p in pts], lb2, ub2)
+        as_vectors = RadialBasis(pts, [[p[1], p[2]] for p in pts], lb2, ub2)
+        @test as_tuples((1.0, 2.0)) ≈ as_vectors((1.0, 2.0))
+        three = RadialBasis(pts, [[p[1], p[2], p[1] + p[2]] for p in pts], lb2, ub2)
+        @test length(three((1.0, 2.0))) == 3
+        @test three((1.0, 2.0)) ≈ [1.0, 2.0, 3.0]
+
+        # Integer responses promote the way the solve does.
+        ints = RadialBasis(pts, [0, 1, 2, 3, 2, 1], lb2, ub2)
+        @test ints((1.0, 2.0)) ≈ 1.0
     end
 
     @testset "sparse construction" begin
@@ -112,6 +130,35 @@ using Surrogates
         spars = RadialBasis(x, y, lb, ub, rad = linearRadial(), sparse = true)
         for p in (1.0, 1.7, 2.5, 3.0)
             @test dense(p) ≈ spars(p)
+        end
+
+        # The sparse assembly has to agree for the other kernels and for vector
+        # responses too, not only for a scalar linear fit.
+        pts = [(0.0, 0.0), (1.0, 2.0), (2.0, 1.0), (3.0, 3.0), (1.0, 3.0), (4.0, 0.5)]
+        vals = [0.0, 1.0, 2.0, 3.0, 2.5, 1.2]
+        lb2 = [0.0, 0.0]
+        ub2 = [4.0, 4.0]
+        for rad in (linearRadial(), cubicRadial(), thinplateRadial())
+            d = RadialBasis(pts, vals, lb2, ub2; rad = rad, sparse = false)
+            sp = RadialBasis(pts, vals, lb2, ub2; rad = rad, sparse = true)
+            @test d((1.5, 2.5)) ≈ sp((1.5, 2.5))
+        end
+        multi = [[p[1], p[2]] for p in pts]
+        d = RadialBasis(pts, multi, lb2, ub2; sparse = false)
+        sp = RadialBasis(pts, multi, lb2, ub2; sparse = true)
+        @test d((1.5, 2.5)) ≈ sp((1.5, 2.5))
+    end
+
+    @testset "multiquadric shape parameter is redundant with scale_factor" begin
+        # `sqrt((c*r)^2 + 1)` is Hardy's `sqrt(r^2 + c0^2)` with `c0 = 1/c`,
+        # times a constant the interpolant is invariant to. Both `c` and
+        # `scale_factor` scale the radius, so they are one parameter.
+        x = collect(range(0.0, 1.0, length = 9))
+        y = sin.(3 .* x)
+        a = RadialBasis(x, y, 0.0, 1.0; rad = multiquadricRadial(2.0), scale_factor = 1.0)
+        b = RadialBasis(x, y, 0.0, 1.0; rad = multiquadricRadial(1.0), scale_factor = 0.5)
+        for p in range(0.0, 1.0, length = 11)
+            @test a(p) ≈ b(p)
         end
     end
 
@@ -286,6 +333,63 @@ using Surrogates
             0 // 1, 3 // 1; rad = linearRadial()
         )
         @test surr(2 // 1) ≈ 4.0
+
+        # `linearRadial` is evaluated through `_linear_distance` and every other
+        # kernel through `rad.phi`, so a precision carried by one branch says
+        # nothing about the other.
+        for rad in (cubicRadial(), multiquadricRadial(), thinplateRadial())
+            for T in (Float32, BigFloat)
+                xs = T[0, 1, 2, 3, 4]
+                ys = T[0, 1, 4, 9, 16]
+                surr = RadialBasis(xs, ys, T(0), T(4); rad = rad)
+                @test eltype(surr.coeff) == T
+                @test surr(T(2.5)) isa T
+                @test surr(T(3)) ≈ T(9) atol = sqrt(eps(T))
+            end
+        end
+    end
+
+    @testset "element types in more than one dimension" begin
+        pts = [(0.0, 0.0), (1.0, 2.0), (2.0, 1.0), (3.0, 3.0), (1.0, 3.0), (4.0, 0.5)]
+        vals = [0.0, 1.0, 2.0, 3.0, 2.5, 1.2]
+        for T in (Float32, BigFloat)
+            xs = [T.(p) for p in pts]
+            ys = T.(vals)
+            for rad in (linearRadial(), cubicRadial(), thinplateRadial())
+                surr = RadialBasis(xs, ys, T.([0.0, 0.0]), T.([4.0, 4.0]); rad = rad)
+                @test eltype(surr.coeff) == T
+                @test surr(T.((1.0, 2.0))) isa T
+                @test surr(T.((1.0, 2.0))) ≈ T(1) atol = sqrt(eps(T))
+            end
+        end
+        # An integer design in more than one dimension promotes the same way.
+        surr = RadialBasis(
+            [(0, 0), (1, 2), (2, 1), (3, 3), (1, 3), (4, 1)], vals, [0, 0], [4, 4]
+        )
+        @test eltype(surr.coeff) == Float64
+        @test surr((1, 2)) ≈ 1.0
+    end
+
+    @testset "input containers" begin
+        pts = [(0.0, 0.0), (1.0, 2.0), (2.0, 1.0), (3.0, 3.0), (1.0, 3.0), (4.0, 0.5)]
+        vals = [0.0, 1.0, 2.0, 3.0, 2.5, 1.2]
+        lb = [0.0, 0.0]
+        ub = [4.0, 4.0]
+        # Samples as tuples or as vectors give the same surrogate.
+        tuples = RadialBasis(pts, vals, lb, ub; rad = linearRadial())
+        vectors = RadialBasis(collect.(pts), vals, lb, ub; rad = linearRadial())
+        @test tuples((1.5, 2.5)) ≈ vectors((1.5, 2.5))
+
+        # A point is a point however it is wrapped.
+        @test tuples((1.5, 2.5)) ≈ tuples([1.5, 2.5])
+        @test tuples((1.5, 2.5)) ≈ tuples([1.5 2.5])
+
+        x1 = [0.0, 1.0, 2.0, 3.0]
+        y1 = [0.0, 1.0, 4.0, 9.0]
+        surr = RadialBasis(x1, y1, 0.0, 3.0; rad = linearRadial())
+        @test surr(2.0) ≈ surr([2.0])
+        @test surr(2.0) ≈ surr((2.0,))
+        @test surr(2.0) ≈ surr(fill(2.0, 1, 1))
     end
 
     @testset "update! leaves the caller's containers alone" begin
@@ -307,5 +411,75 @@ using Surrogates
         @test length(x_nd) == 3
         @test length(surr.x) == 5
         @test surr((2.0, 3.0)) ≈ 4.0
+    end
+    @testset "queries of a different element type than the samples" begin
+        # The accumulator holds coefficient times kernel value, so its type is
+        # the promotion of the two. Taking it from the query alone made an
+        # integer query throw InexactError on the first write.
+        x = [(0.0, 0.0), (1.0, 2.0), (2.0, 1.0), (3.0, 3.0), (1.0, 0.0)]
+        y = [0.0, 1.0, 2.0, 3.0, 1.5]
+        surr = RadialBasis(x, y, [0.0, 0.0], [3.0, 3.0]; rad = linearRadial())
+        @test surr((1, 2)) ≈ surr((1.0, 2.0))
+        @test surr([1, 2]) ≈ surr((1.0, 2.0))
+
+        x1 = [0.0, 1.0, 2.0, 3.0]
+        y1 = [0.0, 1.0, 4.0, 9.0]
+        surr1 = RadialBasis(x1, y1, 0.0, 3.0; rad = linearRadial())
+        @test surr1(2) ≈ surr1(2.0)
+        @test surr1(2) ≈ 4.0
+
+        # An integer *design* promotes the same way.
+        surri = RadialBasis([0, 1, 2, 3], [0, 1, 4, 9], 0, 3; rad = linearRadial())
+        @test surri(2) ≈ 4.0
+        @test surri(2.5) isa Float64
+    end
+
+    @testset "samples added without refitting are caught" begin
+        # `update!` keeps the two containers in step; reaching past it does not.
+        x = [1.0, 2.0, 3.0]
+        y = [4.0, 5.0, 6.0]
+        surr = RadialBasis(x, y, 0.0, 5.0; rad = linearRadial())
+        push!(surr.x, 4.0)
+        err = try
+            surr(2.0)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("4 samples but only 3 coefficients", err.msg)
+    end
+
+    @testset "automatic differentiation" begin
+        # Evaluation accumulates into a local for a scalar response and into a
+        # Zygote buffer for a vector one, so both modes have to be exercised on
+        # both paths.
+        x1 = collect(0.0:0.5:10.0)
+        y1 = x1 .^ 2
+        # Off the nodes: every kernel is a function of `norm(z)`, whose
+        # derivative at a zero difference is 0/0.
+        query = 5.25
+        for rad in (linearRadial(), cubicRadial(), multiquadricRadial(), thinplateRadial())
+            surr = RadialBasis(x1, y1, 0.0, 10.0; rad = rad)
+            fd = ForwardDiff.derivative(surr, query)
+            @test fd isa Number
+            @test Zygote.gradient(surr, query)[1] ≈ fd
+        end
+
+        lb = [0.0, 0.0]
+        ub = [10.0, 10.0]
+        xn = sample(40, lb, ub, SobolSample())
+        surr = RadialBasis(xn, [p[1]^2 + p[2]^2 for p in xn], lb, ub; rad = cubicRadial())
+        g = ForwardDiff.gradient(surr, [2.3, 3.1])
+        @test g isa AbstractVector
+        @test Zygote.gradient(surr, [2.3, 3.1])[1] ≈ g
+
+        # Vector responses go through the buffered path.
+        surr_multi = RadialBasis(
+            xn, [[p[1]^2, p[2]] for p in xn], lb, ub; rad = linearRadial()
+        )
+        J = ForwardDiff.jacobian(p -> surr_multi(p), [2.3, 3.1])
+        @test size(J) == (2, 2)
+        @test Zygote.jacobian(p -> surr_multi(p), [2.3, 3.1])[1] ≈ J
     end
 end


### PR DESCRIPTION
This PR does:

Bug fixes

  - thinplateRadial tested iszero on the sample difference, a MethodError for tuples — the kernel was unusable in more than one dimension. Now tested on norm(z).
  - multiquadricRadial's c = 1.0 default is a Float64 literal, which promoted a Float32 design to Float64. c is now taken to the radius' type.
  - Single- vs multi-output was chosen by typeof(y) == Vector{Float64}, a type equality test, so Float32, BigFloat and integer responses took the wrong branch.
    Replaced by the shared _construct_y_matrix.
  - update! grew rad.x/rad.y with push!/append!, mutating the caller's own vectors. Replaced by the shared _append_samples.
  - The kernel matrix was built at eltype(x), throwing InexactError on integer designs for most scale_factor values; scale_factor and regularization kept their
    Float64 defaults, promoting a Float32 solve. Both are now converted to float(eltype(first(x))).
  - Queries whose element type differed from the samples threw InexactError; the accumulator took its type from the query rather than from coefficient × kernel
    value.
  - The 1D evaluation path had no coefficient-count guard; only ND did. Both now share one.
  - throw("string") replaced by an ArgumentError.

Performance

Removed _approx_rbf(val::Number, …), which sliced coeff[:, i] into a heap-allocated vector per sample; the general path already handled Numbers. Hoisted the per-evaluation linearRadial() construction to a constant, dropped a dead collect(val), replaced the f = rad.phi keyword with applying phi at the call site, and stopped copying the kernel matrix when regularization is zero.


