### PR TITLE
Release Surrogates 7.10.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.10.0"
+version = "7.10.1"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `Surrogates` 7.10.0 -> 7.10.1 (patch).

Source files changed since 7.10.0:
- `src/Radials.jl`

Commits:
- Source changes in src/Radials.jl

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
