### PR TITLE
Release Surrogates 7.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Surrogates"
 uuid = "6fc51010-71bc-11e9-0e15-a3fcc6593c49"
-version = "7.10.1"
+version = "7.10.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `Surrogates` 7.10.1 -> 7.10.2 (patch).

Source files changed since 7.10.1:
- `src/Lobachevsky.jl`

Commits:
- Add 32-bit Core CI lane via test_groups.toml (#608)
- Keep 32-bit CI lane hard-failing. (#609)
- Require PolyChaos 2.1.2 for 32-bit numberPolynomials (#611)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
