### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,69 @@
+using Surrogates, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+lb, ub = 0.0, 10.0
+f(x) = log(x) * x + sin(x)
+xs = lb .+ (ub - lb) .* rand(rng, 50)
+ys = f.(xs)
+
+# 2D surrogate
+lb2, ub2 = [0.0, 0.0], [10.0, 10.0]
+f2(x) = sin(x[1]) * cos(x[2])
+xs2 = collect(
+    zip(
+        lb2[1] .+ (ub2[1] - lb2[1]) .* rand(rng, 40),
+        lb2[2] .+ (ub2[2] - lb2[2]) .* rand(rng, 40)
+    )
+)
+xs2 = [collect(t) for t in xs2]
+ys2 = f2.(xs2)
+
+# =============================================================================
+# Surrogate construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["radial_basis"] = @benchmarkable RadialBasis(
+    $xs, $ys, $lb, $ub
+)
+SUITE["construct"]["kriging"] = @benchmarkable Kriging($xs, $ys, $lb, $ub)
+SUITE["construct"]["linear"] = @benchmarkable LinearSurrogate($xs, $ys, $lb, $ub)
+SUITE["construct"]["inverse_distance"] = @benchmarkable InverseDistanceSurrogate(
+    $xs, $ys, $lb, $ub
+)
+SUITE["construct"]["wendland"] = @benchmarkable Wendland($xs, $ys, $lb, $ub)
+SUITE["construct"]["lobachevsky"] = @benchmarkable LobachevskySurrogate(
+    $xs, $ys, $lb, $ub
+)
+SUITE["construct"]["radial_2d"] = @benchmarkable RadialBasis(
+    $xs2, $ys2, $lb2, $ub2
+)
+
+# =============================================================================
+# Prediction
+# =============================================================================
+
+SUITE["predict"] = BenchmarkGroup()
+
+rad = RadialBasis(xs, ys, lb, ub)
+krig = Kriging(xs, ys, lb, ub)
+
+SUITE["predict"]["radial"] = @benchmarkable $rad(3.5)
+SUITE["predict"]["kriging"] = @benchmarkable $krig(3.5)
+
+# =============================================================================
+# update! and surrogate optimization
+# =============================================================================
+
+SUITE["opt"] = BenchmarkGroup()
+
+SUITE["opt"]["update"] = @benchmarkable update!(s, 5.5, $(f(5.5))) setup = (
+    s = RadialBasis(copy($xs), copy($ys), $lb, $ub)
+)
+SUITE["opt"]["surrogate_optimize"] = @benchmarkable surrogate_optimize(
+    $f, SRBF(), $lb, $ub, s, SobolSample(); maxiters = 20
+) setup = (s = RadialBasis(copy($xs), copy($ys), $lb, $ub))


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~30s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~30s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md